### PR TITLE
設定可能項目の追加

### DIFF
--- a/commands/updater.js
+++ b/commands/updater.js
@@ -1,5 +1,5 @@
 const { SlashCommandBuilder } = require('discord.js');
-const AdminuserIDs = ['1063527758292070591', '1126422758696427552'];
+const { AdminUserIDs } = require('../config.json');
 const childprocess = require('child_process');
 const path = require("path");
 const color = require("colors");
@@ -12,7 +12,7 @@ module.exports = {
 	const executorID = interaction.user.id; // 実行者のユーザーID
 
 	// checkid
-	if (!AdminuserIDs.includes(executorID)) {
+	if (!AdminUserIDs.includes(executorID)) {
     	await interaction.reply('このコマンドはBotの管理者のみ使えます。');
     	return;
     }

--- a/config.json.example
+++ b/config.json.example
@@ -14,6 +14,7 @@
 	"cfZone": "133114688",
 	"cfPurgeUrl": "https://cdn.yourdomain.com/",
 	"AdminRoleID": "00000000000",
+	"AdminUserIDs": ["1063527758292070591", "1126422758696427552"],
 	"mongoDBhost": "127.0.0.1",
 	"mongoDBport": "27017",
 	"mongoDBuser": "admin",

--- a/config.json.example
+++ b/config.json.example
@@ -21,5 +21,6 @@
 	"mongoDBdatabase": "idk",
 	"rconhost1": "192.168.1.255",
 	"rconport1": "25575",
-	"rconpass1": "yourpassword1234"
+	"rconpass1": "yourpassword1234",
+	"syslogChannel": "1151139585791901746"
 }

--- a/discordbot.js
+++ b/discordbot.js
@@ -3,7 +3,7 @@ process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = '1';
 const { Client, GatewayIntentBits, ActivityType } = require('discord.js');
 const fs = require("fs");
 const path = require("path");
-const { token, linkPort, linkDomain } = require('./config.json');
+const { token, linkPort, linkDomain, syslogChannel } = require('./config.json');
 const express = require("express");
 const app = express();
 const axios = require('axios');
@@ -128,7 +128,7 @@ client.on('ready', async () => {
 	console.log(`Registering commands...`)
 	await client.application.commands.set(commands.map(x => x.data.toJSON()));
 	console.log(`${cgreen}Ready!${creset}`);
-	let SyslogChannel = client.channels.cache.get("1151139585791901746");
+	let SyslogChannel = client.channels.cache.get(syslogChannel);
 	SyslogChannel.send('Discord.js Bot is Ready!')
 })
 


### PR DESCRIPTION
主にハードコーディングされているIDを `/config.json` で設定できるように変更しました。

## `syslogChannel`
### Fixed issue
[/discordbot.js:132](https://github.com/ringo360/Discord.js_Bot/blob/f2fce4002138ed845edbe97b9f93aa70760c7e66/discordbot.js#L132) で `SyslogChannel` が undefined であるためエラーが発生
```
TypeError: Cannot read properties of undefined (reading 'send')
    at Client.<anonymous> (/home/takejohn/Discord.js_Bot/discordbot.js:132:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

### Solution
チャンネルIDをハードコーディングするのではなく `/config.json` で `syslogChannel` として設定可能に変更

## `AdminUserIds`
### Fixed issue
Botの管理者のユーザーIDが固定のため `/update` コマンドを使用できない

### Solution
管理者のユーザーIDを `/config.json` で `AdminUserIDs` として設定可能に変更