### PR TITLE
CDNアップロードメッセージ周りを改良

### DIFF
--- a/commands/upload.js
+++ b/commands/upload.js
@@ -56,7 +56,8 @@ module.exports = {
 			// console.log(res)
 			// console.log("==========")
 			// console.log(res2)
-            interaction.editReply('アップロードしました!\nhttps://cdn.ringoxd.dev'(isPrivate ? " /private" : "") + `/${res2.data.fileName}`);
+            const cdnURL = config.cdnRootURL + (isPrivate ? "private/" : "") + res2.data.fileName;
+            interaction.editReply('アップロードしました!\n' + cdnURL);
             const user = interaction.user;
             const dmChannel = await user.createDM();
             dmChannel.send({
@@ -65,7 +66,7 @@ module.exports = {
                     color: 0x5865f2,
                     fields: [{
                         name: "URL",
-                        value: "```" + "https://cdn.ringoxd.dev/" + (isPrivate ? " private/" : "") + res2.data.fileName + "```" + "\n[Click to copy!](https://paste-pgpj.onrender.com/?p=" + "https://cdn.ringoxd.dev/" + (isPrivate ? " private/" : "") + `${res2.data.fileName})`,
+                        value: "```" + cdnURL + "```" + "\n[Click to copy!](https://paste-pgpj.onrender.com/?p=" + encodeURIComponent(cdnURL) + ")",
                     }]
                 }]
             });

--- a/config.json.example
+++ b/config.json.example
@@ -8,6 +8,7 @@
 	"linkPort": 8264,
 	"cdnUploadURL": "http://192.168.1.255/upload-discord",
 	"cdnUploadURL2": "http://192.168.1.255/upload-discord",
+	"cdnRootURL": "https://cdn.ringoxd.dev/",
 	"uploadAllowUsers": ["00000000000","16326412825651210244096"],
 	"applicationId": "000000",
 	"cfToken": "ORIMOTOKAIRUNDHUAUNDHUAUN",


### PR DESCRIPTION
* `/config.json` に `cdnRootURL` プロパティを追加し、アップロード時のメッセージに添付されるURLを適当なものに設定可能に変更
* DMに送信するコピー用リンクを生成する際、 `encodeURIComponent` 関数を用いることで `&` や `#` の特殊文字が入ったファイル名でも正常に動作するように変更