### PR TITLE
Pager に options.color が反映されない問題を修正

### DIFF
--- a/util/pager.js
+++ b/util/pager.js
@@ -141,6 +141,7 @@ class Pager {
         const fieldName = this.getFieldName();
         const description = this.getDescription();
         embedBuilder.setTitle(this.getTitle());
+        embedBuilder.setColor(this.getColor());
         if (fieldName == null) {
             embedBuilder.setDescription(description);
         } else {


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
`Pager` がコンストラクタ引数の `options.color` を埋め込みの色に反映するように修正しました。

## 変更点

<!--- 変更点の記述 -->
* Pager のページを変更する際に埋め込みに色を設定するコードを追加

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
