### PR TITLE
/mc_srvlookupコマンドでエラーが発生する問題を修正

### DIFF
--- a/commands/mc_srvlookup.js
+++ b/commands/mc_srvlookup.js
@@ -12,8 +12,8 @@ module.exports = {
 				.setRequired(true)
         ),
     execute: async function (interaction) {
-        let domainName = "_minecraft._tcp." + interaction.options.getString("domain");
-		let result = {};
+        const domain = interaction.options.getString("domain");
+        const domainName = "_minecraft._tcp." + domain;
 		try {
             dns.resolveSrv(domainName, (err, records) => {
                 if (err) {


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
/mc_srvlookup を実行しようとするとエラーが発生して実行できない問題がありました。
```
2|explode- | ReferenceError: domain is not defined
2|explode- |     at QueryReqWrap.callback (/home/takejohn/Discord.js_Bot/commands/mc_srvlookup.js:20:70)
2|explode- |     at QueryReqWrap.onresolve [as oncomplete] (node:internal/dns/callback_resolver:45:10)
```

変数 `domain` を追加して修正しました。

## 変更点

<!--- 変更点の記述 -->
* 適切な変数の追加

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
