### PR TITLE
サーバーで音楽の音量のデフォルト値を設定できるように変更

### DIFF
--- a/commands/play.js
+++ b/commands/play.js
@@ -1,7 +1,6 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, CommandInteraction } = require('discord.js');
 const { useMainPlayer, QueryType } = require('discord-player');
-const { getPlayableVoiceChannelId, getDuration } = require('../util/players');
-const Timespan = require('../util/timespan');
+const { getPlayableVoiceChannelId, getDuration, loadVolumeSetting } = require('../util/players');
 const { LANG, strFormat } = require('../util/languages');
 // const ytdl = require('ytdl-core'); さよなら!!!
 // const yts = require('yt-search'); 検索機能？要らんやろ
@@ -11,69 +10,72 @@ module.exports = {
     data: new SlashCommandBuilder()
         .setName(LANG.commands.play.name)
         .setDescription(LANG.commands.play.description)
-		.addStringOption(option =>
-			option
-				.setName(LANG.commands.play.options.query.name)
-				.setDescription(LANG.commands.play.options.query.description)
-				.setRequired(true)
-		),
-    execute: async function (interaction) {
-		const voiceChannelId = getPlayableVoiceChannelId(interaction);
-		if (voiceChannelId == null)
+        .addStringOption(option =>
+            option
+                .setName(LANG.commands.play.options.query.name)
+                .setDescription(LANG.commands.play.options.query.description)
+                .setRequired(true)
+        ),
+    execute: async function (/** @type {CommandInteraction<unknown>} */ interaction) {
+        const voiceChannelId = getPlayableVoiceChannelId(interaction);
+        if (voiceChannelId == null)
             return await interaction.reply({ content: LANG.common.message.notPlayableError, ephemeral: true });
 
-		const player = useMainPlayer();
-		const query = interaction.options.get(LANG.commands.play.options.query.name).value;
+        const player = useMainPlayer();
+        const query = interaction.options.get(LANG.commands.play.options.query.name).value;
 
-		await interaction.deferReply();
+        await interaction.deferReply();
 
-		try {
-			const searchResult = await player.search(query, { requestedBy: interaction.user, searchEngine: QueryType.AUTO });
+        try {
+            const vol = await loadVolumeSetting(interaction.guildId);
 
-    		if (!searchResult || searchResult.tracks.length == 0 || !searchResult.tracks) {
-    		  return interaction.followUp(LANG.commands.play.notFound);
-    		}
-    		const res = await player.play(voiceChannelId, searchResult, {
-    		  nodeOptions: {
-    		    metadata: {
-    		      channel: interaction.channel,
-    		      client: interaction.guild.members.me,
-    		      requestedBy: interaction.user,
-    		    },
-				// volume: 5,
-    		    bufferingTimeout: 15000,
-    		    leaveOnStop: true,
-    		    leaveOnStopCooldown: 5000,
-    		    leaveOnEnd: true,
-    		    leaveOnEndCooldown: 15000,
-    		    leaveOnEmpty: true,
-    		    leaveOnEmptyCooldown: 300000,
-    		    skipOnNoStream: true,
-    		  },
-    		});
+            const searchResult = await player.search(query, { requestedBy: interaction.user, searchEngine: QueryType.AUTO });
 
-			const duration = getDuration(res.track);
-			const message = strFormat(LANG.commands.play.trackAdded, ['**' + (res.track.playlist
-				? strFormat(LANG.common.message.playerTrack, { title: res.track.playlist.title, duration })
-				: strFormat(LANG.commands.play.authorAndTrack, {
-					author: res.track.author,
-					track: strFormat(LANG.common.message.playerTrack, { title: res.track.title, duration })
-				})) + '**']);
+            if (!searchResult || searchResult.tracks.length == 0 || !searchResult.tracks) {
+                return interaction.followUp(LANG.commands.play.notFound);
+            }
+            const res = await player.play(voiceChannelId, searchResult, {
+                nodeOptions: {
+                    metadata: {
+                        channel: interaction.channel,
+                        client: interaction.guild.members.me,
+                        requestedBy: interaction.user,
+                    },
+                    // volume: 5,
+                    bufferingTimeout: 15000,
+                    leaveOnStop: true,
+                    leaveOnStopCooldown: 5000,
+                    leaveOnEnd: true,
+                    leaveOnEndCooldown: 15000,
+                    leaveOnEmpty: true,
+                    leaveOnEmptyCooldown: 300000,
+                    skipOnNoStream: true,
+                    volume: vol
+                },
+            });
 
-			return interaction.followUp({
-				embeds: [{
-					title: message,
-					color: 0x5865f2,
-					footer: {
+            const duration = getDuration(res.track);
+            const message = strFormat(LANG.commands.play.trackAdded, ['**' + (res.track.playlist
+                ? strFormat(LANG.common.message.playerTrack, { title: res.track.playlist.title, duration })
+                : strFormat(LANG.commands.play.authorAndTrack, {
+                    author: res.track.author,
+                    track: strFormat(LANG.common.message.playerTrack, { title: res.track.title, duration })
+                })) + '**']);
+
+            return interaction.followUp({
+                embeds: [{
+                    title: message,
+                    color: 0x5865f2,
+                    footer: {
                         text: strFormat(LANG.commands.play.requestedBy, [interaction.user.tag])
                     },
-				}]
-			})
-		} catch (e) {
-			// let's return error if something failed
-			console.error(e);
-			return interaction.followUp(strFormat(LANG.commands.play.generalError, [e]));
-		}
+                }]
+            })
+        } catch (e) {
+            // let's return error if something failed
+            console.error(e);
+            return interaction.followUp(strFormat(LANG.commands.play.generalError, [e]));
+        }
 
 
     }

--- a/commands/volume.js
+++ b/commands/volume.js
@@ -1,46 +1,53 @@
-const { SlashCommandBuilder } = require('discord.js');
-const { useQueue } = require('discord-player');
+const { SlashCommandBuilder, CommandInteraction } = require('discord.js');
 const { LANG, strFormat } = require('../util/languages');
+const { getPlayableVoiceChannelId, getPlayingQueue } = require('../util/players');
+const players = require('../util/players');
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName(LANG.commands.volume.name)
         .setDescription(LANG.commands.volume.description)
-		.addIntegerOption(option =>
-			option
-				.setName(LANG.commands.volume.options.volume.name)
-				.setDescription(LANG.commands.volume.options.volume.description)
-				.setRequired(true)
-				.setMinValue(0)
-				.setMaxValue(100)
-		),
-    execute: async function (interaction) {
-        const queue = useQueue(interaction.guildId);
-		const vol = interaction.options.getInteger(LANG.commands.volume.options.volume.name);
+        .addIntegerOption(option =>
+            option
+                .setName(LANG.commands.volume.options.volume.name)
+                .setDescription(LANG.commands.volume.options.volume.description)
+                .setRequired(true)
+                .setMinValue(0)
+                .setMaxValue(100)
+        )
+        .addBooleanOption(option =>
+            option
+                .setName(LANG.commands.volume.options.keep.name)
+                .setDescription(LANG.commands.volume.options.keep.description)
+                .setRequired(false)),
+    execute: async function (/** @type {CommandInteraction<unknown>} */ interaction) {
+        const vol = interaction.options.getInteger(LANG.commands.volume.options.volume.name);
+        const keep = interaction.options.getBoolean(LANG.commands.volume.options.keep.name) ?? false;
 
-        const member = interaction.member;
-        const channel = member.voice.channel;
-
-        if (!channel) {
+        const channel = getPlayableVoiceChannelId(interaction);
+        if (channel == null) {
             return await interaction.reply({ content: LANG.common.message.notPlayableError, ephemeral: true });
         }
 
-		if (
-			interaction.guild.members.me.voice.channelId &&
-			interaction.member.voice.channelId !== interaction.guild.members.me.voice.channelId
-		)
-			return await interaction.reply({ content: LANG.common.message.notPlayableError, ephemeral: true });
-
-    	if (!queue || !queue.isPlaying())
-    	  return interaction.reply({ content: LANG.common.message.noTracksPlayed, ephemeral: true });
+        const queue = getPlayingQueue(interaction);
+        if (queue == null)
+            return interaction.reply({ content: LANG.common.message.noTracksPlayed, ephemeral: true });
 
 
-		try {
-			queue.node.setVolume(vol)
-			interaction.reply(strFormat(LANG.commands.volume.volumeSet, ['**' + vol + '**']));
-		} catch (e) {
-			interaction.reply(LANG.commands.volume.error + '\n' + '```ansi\n' + "\x1b[31m" + e + '\n```');
-			console.error(e);
-		}
+        try {
+            if (keep)
+                await players.saveVolumeSetting(interaction.guildId, vol);
+
+            queue.node.setVolume(vol)
+            interaction.reply(
+                strFormat(
+                    keep ? LANG.commands.volume.volumeSave : LANG.commands.volume.volumeSet,
+                    ['**' + vol + '**']
+                )
+            );
+        } catch (e) {
+            interaction.reply(LANG.commands.volume.error + '\n' + '```ansi\n' + "\x1b[31m" + e + '\n```');
+            console.error(e);
+        }
     }
 };

--- a/language/default.json
+++ b/language/default.json
@@ -592,9 +592,14 @@
                 "volume": {
                     "name": "volume",
                     "description": "音量を設定(1~100)"
+                },
+                "keep": {
+                    "name": "keep",
+                    "description": "サーバーのデフォルト値として設定するか"
                 }
             },
             "volumeSet": "音量を${0}に設定しました!",
+            "volumeSave": "サーバーの規定値として音量を${0}に設定しました!",
             "error": "うわーん！吐血しちゃったよぉ..."
         }
     }

--- a/language/en.json
+++ b/language/en.json
@@ -592,9 +592,14 @@
                 "volume": {
                     "name": "volume",
                     "description": "Set the volume (1-100)"
+                },
+                "keep": {
+                    "name": "keep",
+                    "description": "Whether to set the volume as the default value of the server"
                 }
             },
             "volumeSet": "Set the volume to ${0}!",
+            "volumeSave": "Set the volume to ${0} as the default value of the server!",
             "error": "An error occurred"
         }
     }

--- a/language/ja.json
+++ b/language/ja.json
@@ -592,9 +592,14 @@
                 "volume": {
                     "name": "volume",
                     "description": "音量を設定(1~100)"
+                },
+                "keep": {
+                    "name": "keep",
+                    "description": "サーバーのデフォルト値として設定するか"
                 }
             },
             "volumeSet": "音量を${0}に設定しました!",
+            "volumeSave": "サーバーの規定値として音量を${0}に設定しました!",
             "error": "エラーが発生しました"
         }
     }

--- a/util/players.js
+++ b/util/players.js
@@ -1,5 +1,6 @@
 const { useQueue, Track } = require('discord-player');
 const Timespan = require('./timespan');
+const mongodb = require('../internal/mongodb');
 
 /**
  * 音楽プレイヤーに関わるユーティリティ関数群。
@@ -41,6 +42,38 @@ module.exports = {
      */
     getDuration(track) {
         return new Timespan({ millis: track.durationMS });
+    },
+
+    /**
+     * サーバーでの音量設定を保存する。
+     * @param {string} guildId ギルド ID
+     * @param {number} volume 音量
+     */
+    async saveVolumeSetting(guildId, volume) {
+        const volumeCollection = mongodb.connection.collection('volumes');
+        await volumeCollection.updateOne(
+            { guild: guildId },
+            {
+                $set: {
+                    guild: guildId,
+                    volume: volume
+                }
+            },
+            { upsert: true }
+        );
+    },
+
+    /**
+     * サーバーでの音量設定を取得する。
+     * @param {string} guildId ギルド ID
+     * @returns {Promise<number | undefined>} 音量
+     */
+    async loadVolumeSetting(guildId) {
+        const volumeCollection = mongodb.connection.collection('volumes');
+        const result = await volumeCollection.findOne({ guild: guildId });
+        if (result != null) {
+            return result.volume;
+        }
     }
 
 };


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
音楽の音量を保存できるように変更しました。
/volume コマンドの keep オプションを True にすることでそのサーバーでの音量のデフォルト値を変更できます。

## 変更点

<!--- 変更点の記述 -->
* /volume コマンドに keep オプションを追加。MongoDB の `volumes` コレクションに情報を保存して /play コマンドが実行されたときに読み出します。
* `comands/play.js`, `commands/volume.js` のインデントをスペース4個に統一

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
