### PR TITLE
TempLinkSrv に対応

### DIFF
--- a/commands/templink.js
+++ b/commands/templink.js
@@ -1,61 +1,53 @@
 const { SlashCommandBuilder } = require('discord.js');
-const { linkDomain } = require("../config.json");
 const { LANG, strFormat } = require('../util/languages');
-
-function makeid(length) {
-    let result = '';
-    const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
-    const charactersLength = characters.length;
-    let counter = 0;
-    while (counter < length) {
-        result += characters.charAt(Math.floor(Math.random() * charactersLength));
-        counter += 1;
-    }
-    return result;
-}
+const {
+    areTempLinksEnabled,
+    createTempLink,
+    InvalidURLError
+} = require('../internal/templinks');
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName(LANG.commands.templink.name)
         .setDescription(LANG.commands.templink.description)
-        .addStringOption(option =>
+        .addStringOption((option) =>
             option
                 .setName(LANG.commands.templink.options.url.name)
                 .setDescription(LANG.commands.templink.options.url.description)
                 .setRequired(true)
         ),
     execute: async function (interaction) {
-        if (!interaction.client.templinks) {
+        if (!areTempLinksEnabled()) {
             return interaction.reply(LANG.commands.templink.internalError);
         }
-        let url = interaction.options.get(LANG.commands.templink.options.url.name).value;
+        let url = interaction.options.get(
+            LANG.commands.templink.options.url.name
+        ).value;
         try {
-            new URL(url);
-        } catch {
+            const { id, link } = createTempLink(url);
+            console.log(
+                strFormat(LANG.commands.templink.linkCreated, { id, url })
+            );
+            interaction.reply({
+                content: null,
+                embeds: [
+                    {
+                        title: LANG.commands.templink.result.title,
+                        description: LANG.commands.templink.result.description,
+                        fields: [
+                            {
+                                name: LANG.commands.templink.result.link,
+                                value: link
+                            }
+                        ]
+                    }
+                ]
+            });
+        } catch (e) {
             await interaction.reply({
                 content: LANG.commands.templink.invalidUrlError.join('\n'),
                 ephemeral: true
             });
-            return;
         }
-        let id = makeid(5);
-        console.log(strFormat(LANG.commands.templink.linkCreated, { id, url }));
-        interaction.client.templinks.push({
-            id: id,
-            url: url,
-            createdAt: new Date(),
-            period: 1000 * 300
-        });
-        interaction.reply({
-            content: null,
-            embeds: [{
-                title: LANG.commands.templink.result.title,
-				description: LANG.commands.templink.result.description,
-				fields: [{
-					name: LANG.commands.templink.result.link,
-					value: `https://${linkDomain}/${id}`
-				}]
-            }]
-        })
     }
 };

--- a/commands/templink.js
+++ b/commands/templink.js
@@ -1,10 +1,11 @@
-const { SlashCommandBuilder } = require('discord.js');
+const { SlashCommandBuilder, CommandInteraction } = require('discord.js');
 const { LANG, strFormat } = require('../util/languages');
 const {
     areTempLinksEnabled,
     createTempLink,
     InvalidURLError
 } = require('../internal/templinks');
+const { AxiosError } = require('axios');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -16,7 +17,7 @@ module.exports = {
                 .setDescription(LANG.commands.templink.options.url.description)
                 .setRequired(true)
         ),
-    execute: async function (interaction) {
+    execute: async function (/** @type {CommandInteraction} */ interaction) {
         if (!areTempLinksEnabled()) {
             return interaction.reply(LANG.commands.templink.internalError);
         }
@@ -24,7 +25,7 @@ module.exports = {
             LANG.commands.templink.options.url.name
         ).value;
         try {
-            const { id, link } = createTempLink(url);
+            const { id, link } = await createTempLink(url, 1000 * 300);
             console.log(
                 strFormat(LANG.commands.templink.linkCreated, { id, url })
             );
@@ -44,10 +45,27 @@ module.exports = {
                 ]
             });
         } catch (e) {
-            await interaction.reply({
-                content: LANG.commands.templink.invalidUrlError.join('\n'),
-                ephemeral: true
-            });
+            if (e instanceof InvalidURLError) {
+                await interaction.reply({
+                    content: LANG.commands.templink.invalidUrlError.join('\n'),
+                    ephemeral: true
+                });
+            } else if (e instanceof AxiosError) {
+                await interaction.reply({
+                    content:
+                        strFormat(LANG.commands.templink.httpError, [
+                            e.response?.status
+                        ]) +
+                        '\n' +
+                        e.response?.data?.error?.description,
+                    ephemeral: true
+                });
+            } else {
+                await interaction.reply({
+                    content: 'Unknown error',
+                    ephemeral: true
+                });
+            }
         }
     }
 };

--- a/commands/templink.js
+++ b/commands/templink.js
@@ -62,9 +62,10 @@ module.exports = {
                 });
             } else {
                 await interaction.reply({
-                    content: 'Unknown error',
+                    content: LANG.commands.templink.generalError,
                     ephemeral: true
                 });
+                console.error(e);
             }
         }
     }

--- a/config.json.example
+++ b/config.json.example
@@ -1,6 +1,8 @@
 {
 	"kairun": 8264,
 	"token": "YourDiscordBotTokenHere",
+	"tempLinkSrvToken": "Tl0_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+	"tempLinkSrvApiUrl": "https://link.example.com/api",
 	"linkDomain": "link.yourdomain.com",
 	"linkPort": 8264,
 	"cdnUploadURL": "http://192.168.1.255/upload-discord",

--- a/config.json.example
+++ b/config.json.example
@@ -2,7 +2,7 @@
 	"kairun": 8264,
 	"token": "YourDiscordBotTokenHere",
 	"tempLinkSrvToken": "Tl0_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
-	"tempLinkSrvApiUrl": "https://link.example.com/api",
+	"tempLinkSrvPostURL": "https://link.example.com/api/links",
 	"linkDomain": "link.yourdomain.com",
 	"linkPort": 8264,
 	"cdnUploadURL": "http://192.168.1.255/upload-discord",

--- a/discordbot.js
+++ b/discordbot.js
@@ -3,11 +3,9 @@ process.env["NODE_TLS_REJECT_UNAUTHORIZED"] = '1';
 const { Client, GatewayIntentBits, ActivityType } = require('discord.js');
 const fs = require("fs");
 const path = require("path");
-const { token, linkPort, linkDomain, syslogChannel } = require('./config.json');
-const express = require("express");
-const app = express();
+const { token, syslogChannel } = require('./config.json');
+const { enableTempLinks } = require('./internal/templinks');
 const axios = require('axios');
-const server = require("http").Server(app);
 const { Player } = require('discord-player');
 const internal = require('stream');
 process.env["FFMPEG_PATH"] = path.join(__dirname,"ffmpeg")
@@ -53,21 +51,6 @@ async function getRedirectUrl(shortUrl) {
 		return `${LANG.discordbot.getRedirectUrl.error} ${error.message}`
     }
 }
-function unicodeEscape(str) {
-	if (!String.prototype.repeat) {
-		String.prototype.repeat = function (digit) {
-			var result = '';
-			for (var i = 0; i < Number(digit); i++) result += str;
-			return result;
-		};
-	}
-	var strs = str.split(''), hex, result = '';
-	for (var i = 0, len = strs.length; i < len; i++) {
-		hex = strs[i].charCodeAt(0).toString(16);
-		result += '\\u' + ('0'.repeat(Math.abs(hex.length - 4))) + hex;
-	}
-	return result;
-};
 
 //!RUN=======================
 
@@ -104,22 +87,9 @@ const player = new Player(client);
 player.extractors.loadDefault();
 console.log(LANG.discordbot.main.setupActivityCalling);
 activity.setupActivity(client);
-//?Ignore this
-setInterval(() => {
-	if (!client.templinks) return;
-	client.templinks = client.templinks.filter((link) => {
-		if ((Date.now() - link.createdAt.valueOf()) > link.period) {
-			console.log(strFormat(LANG.discordbot.interval.linkExpired, [link.id]));
-			return false;
-		} else {
-			return true;
-		}
-	});
-}, 1000);
-//?=
 
 client.on('ready', async () => {
-	client.templinks = [];
+	enableTempLinks();
 	console.log(strFormat(LANG.discordbot.ready.loggedIn, { cgreen, creset, tag: client.user.tag }));
 	client.user.setPresence({
 		activities: [{
@@ -134,7 +104,7 @@ client.on('ready', async () => {
 	console.log(cgreen + LANG.discordbot.ready.commandsReady + creset);
 	let SyslogChannel = client.channels.cache.get(syslogChannel);
 	SyslogChannel.send(LANG.discordbot.ready.sysLog);
-})
+});
 
 
 client.on("interactionCreate", async interaction => {
@@ -247,53 +217,6 @@ client.on('messageCreate', async (message) => {
 });
 
 
-//!link
-app.get("/oembed/:linkCode", async (req, res) => {
-	if (!client.templinks) return res.sendStatus(500);
-	let link = client.templinks.find(x => x.id == req.params.linkCode);
-	if (!link) {
-		return res.sendStatus(404);
-	}
-	res.json({
-		"version": "1.0",
-		"title": `${link.url}`,
-		"type": "link",
-		"author_name": LANG.discordbot.linkGet.authorName.join('\n'),
-		"provider_name": LANG.discordbot.linkGet.providerName,
-		"provider_url": "https://ringoxd.dev/",
-		"url": link.url
-	});
-});
-
-
-app.get("/", async (req, res) => {
-	if (!client.templinks) return res.sendStatus(500);
-	let link = client.templinks.find(x => x.id == req.params.linkCode);
-	if (!link) {
-		return res.status(404).send(`<center><h1>${LANG.discordbot.linkGet.rootContentTitle}</h1>\n<hr>\n${LANG.discordbot.linkGet.contentFooter}</center>`);
-	}
-	res.send()
-});
-
-app.get("/:linkCode", async (req, res) => {
-
-	let remoteIp = req.headers["cf-connecting-ip"];
-	let logPath = path.join(__dirname, "accesslog.txt");
-	if (!fs.existsSync(logPath))
-		fs.writeFileSync(logPath, "Access Log================\n");
-	fs.appendFileSync(logPath, `IP: ${remoteIp} | ${req.originalUrl}\n`)
-
-	if (!client.templinks) return res.sendStatus(500);
-	let link = client.templinks.find(x => x.id == req.params.linkCode);
-	if (!link) {
-		return res.status(404).send(`<center><h1>${LANG.discordbot.linkGet.notFoundContentTitle}</h1>\n<hr>\n${LANG.discordbot.linkGet.contentFooter}</center>`);
-	}
-	res.send(
-		`<script>location.href="${unicodeEscape(link.url)}"</script>` +
-		`\n<link rel="alternate" type="application/json+oembed" href="https://${linkDomain}/oembed/${link.id}" />`
-	)
-});
-
 //!EVENTS
 player.events.on('playerStart', (queue, track) => {
     // we will later define queue.metadata object while creating the queue
@@ -322,8 +245,3 @@ process.on('uncaughtException', function (err) {
 	console.error(err);
 });
 
-
-
-server.listen(linkPort, () => {
-	console.log(strFormat(LANG.discordbot.serverListen.tempLinkReady, { linkPort, linkDomain }));
-});

--- a/internal/templinks.js
+++ b/internal/templinks.js
@@ -1,0 +1,182 @@
+const express = require('express');
+const app = express();
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { LANG, strFormat } = require('../util/languages');
+const { linkPort, linkDomain } = require('../config.json');
+
+/**
+ * @typedef {Object} TempLink
+ * @property {string} id リンク ID
+ * @property {string} url リンク先
+ * @property {Date} createdAt リンクの作成日時
+ * @property {number} period リンクの有効期間 (ミリ秒)
+ */
+
+/**
+ * @typedef {Object} TempLinkInfo
+ * @property {string} id リンク ID
+ * @property {string} link リンクの URL
+ */
+
+class InvalidURLError extends TypeError {
+    static {
+        InvalidURLError.prototype.name = 'InvalidURLError';
+    }
+
+    /**
+     * @param {TypeError} cause
+     */
+    constructor(cause) {
+        super(cause.message);
+        this.cause = cause;
+    }
+}
+
+/** @type {TempLink[] | null} */
+let tempLinks = null;
+
+setInterval(() => {
+    if (!tempLinks) return;
+    tempLinks = tempLinks.filter((link) => {
+        if (Date.now() - link.createdAt.valueOf() > link.period) {
+            console.log(
+                strFormat(LANG.discordbot.interval.linkExpired, [link.id])
+            );
+            return false;
+        } else {
+            return true;
+        }
+    });
+}, 1000);
+
+app.get('/oembed/:linkCode', async (req, res) => {
+    if (!tempLinks) return res.sendStatus(500);
+    let link = tempLinks.find((x) => x.id == req.params.linkCode);
+    if (!link) {
+        return res.sendStatus(404);
+    }
+    res.json({
+        version: '1.0',
+        title: link.url,
+        type: 'link',
+        author_name: LANG.discordbot.linkGet.authorName.join('\n'),
+        provider_name: LANG.discordbot.linkGet.providerName,
+        provider_url: 'https://ringoxd.dev/',
+        url: link.url
+    });
+});
+
+app.get('/', async (req, res) => {
+    if (!tempLinks) return res.sendStatus(500);
+    let link = tempLinks.find((x) => x.id == req.params.linkCode);
+    if (!link) {
+        return res
+            .status(404)
+            .send(
+                `<center><h1>${LANG.discordbot.linkGet.rootContentTitle}</h1>\n<hr>\n${LANG.discordbot.linkGet.contentFooter}</center>`
+            );
+    }
+    res.send();
+});
+
+function unicodeEscape(str) {
+    if (!String.prototype.repeat) {
+        String.prototype.repeat = function repeat(digit) {
+            var result = '';
+            for (var i = 0; i < Number(digit); i++) result += str;
+            return result;
+        };
+    }
+    var strs = str.split(''),
+        hex,
+        result = '';
+    for (var i = 0, len = strs.length; i < len; i++) {
+        hex = strs[i].charCodeAt(0).toString(16);
+        result += '\\u' + '0'.repeat(Math.abs(hex.length - 4)) + hex;
+    }
+    return result;
+}
+
+app.get('/:linkCode', async (req, res) => {
+    let remoteIp = req.headers['cf-connecting-ip'];
+    let logPath = path.join(__dirname, 'accesslog.txt');
+    if (!fs.existsSync(logPath))
+        fs.writeFileSync(logPath, 'Access Log================\n');
+    fs.appendFileSync(logPath, `IP: ${remoteIp} | ${req.originalUrl}\n`);
+
+    if (!tempLinks) return res.sendStatus(500);
+    let link = tempLinks.find((x) => x.id == req.params.linkCode);
+    if (!link) {
+        return res
+            .status(404)
+            .send(
+                `<center><h1>${LANG.discordbot.linkGet.notFoundContentTitle}</h1>\n<hr>\n${LANG.discordbot.linkGet.contentFooter}</center>`
+            );
+    }
+    res.send(
+        `<script>location.href="${unicodeEscape(link.url)}"</script>` +
+            `\n<link rel="alternate" type="application/json+oembed" href="https://${linkDomain}/oembed/${link.id}" />`
+    );
+});
+
+function enableTempLinks() {
+    tempLinks = [];
+
+    const server = new http.Server(app);
+    server.listen(linkPort, () => {
+        console.log(
+            strFormat(LANG.discordbot.serverListen.tempLinkReady, {
+                linkPort,
+                linkDomain
+            })
+        );
+    });
+}
+
+function areTempLinksEnabled() {
+    return tempLinks != null;
+}
+
+function makeId(length) {
+    let result = '';
+    const characters =
+        'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    const charactersLength = characters.length;
+    let counter = 0;
+    while (counter < length) {
+        result += characters.charAt(
+            Math.floor(Math.random() * charactersLength)
+        );
+        counter += 1;
+    }
+    return result;
+}
+
+/**
+ * @param {string} url リンク先
+ * @returns {TempLinkInfo} 作成されたリンクの情報
+ */
+function createTempLink(url) {
+    try {
+        new URL(url);
+    } catch (e) {
+        throw new InvalidURLError(e);
+    }
+    const id = makeId(5);
+    tempLinks.push({
+        id,
+        url,
+        createdAt: new Date(),
+        period: 1000 * 300
+    });
+    return { id, link: `https://${linkDomain}/${id}` };
+}
+
+module.exports = {
+    InvalidURLError,
+    enableTempLinks,
+    areTempLinksEnabled,
+    createTempLink
+};

--- a/language/default.json
+++ b/language/default.json
@@ -504,7 +504,8 @@
                 "title": "TempLinkを生成しました!",
                 "description": "5分間のみ使用できます。",
                 "link": "リンク"
-            }
+            },
+            "httpError": "エラーが発生しました: ${0}"
         },
         "testx": {
             "name": "dev01",

--- a/language/default.json
+++ b/language/default.json
@@ -505,7 +505,8 @@
                 "description": "5分間のみ使用できます。",
                 "link": "リンク"
             },
-            "httpError": "エラーが発生しました: ${0}"
+            "httpError": "エラーが発生しました: ${0}",
+            "generalError": "不明なエラーが発生しました"
         },
         "testx": {
             "name": "dev01",

--- a/language/en.json
+++ b/language/en.json
@@ -504,7 +504,8 @@
                 "title": "Generated a TempLink!",
                 "description": "Available for 5 minutes only",
                 "link": "Link"
-            }
+            },
+            "httpError": "An error occurred: ${0}"
         },
         "testx": {
             "name": "dev01",

--- a/language/en.json
+++ b/language/en.json
@@ -499,7 +499,7 @@
             },
             "internalError": "Internal error",
             "invalidUrlError": ["The URL is invalid.", "Enter the URL including https://"],
-            "linkCreated": "[TempLink] Link: ${id} has generated. Link destination: ${url}",
+            "linkCreated": "[TempLink] Link: ${id} has been generated. Link destination: ${url}",
             "result": {
                 "title": "Generated a TempLink!",
                 "description": "Available for 5 minutes only",

--- a/language/en.json
+++ b/language/en.json
@@ -34,7 +34,7 @@
             "afterUrl": "After: ${0}"
         },
         "linkGet": {
-            "authorName": "Shortened link\ndestination:",
+            "authorName": ["Shortened link", "destination:"],
             "providerName": "Sekai.Explode",
             "rootContentTitle": "You can find nothing here",
             "notFoundContentTitle": "The shortened link was not found",

--- a/language/en.json
+++ b/language/en.json
@@ -505,7 +505,8 @@
                 "description": "Available for 5 minutes only",
                 "link": "Link"
             },
-            "httpError": "An error occurred: ${0}"
+            "httpError": "An error occurred: ${0}",
+            "generalError": "An unknown error occurred"
         },
         "testx": {
             "name": "dev01",

--- a/language/ja.json
+++ b/language/ja.json
@@ -504,7 +504,8 @@
                 "title": "TempLinkを生成しました!",
                 "description": "5分間のみ使用できます。",
                 "link": "リンク"
-            }
+            },
+            "httpError": "エラーが発生しました: ${0}"
         },
         "testx": {
             "name": "dev01",

--- a/language/ja.json
+++ b/language/ja.json
@@ -505,7 +505,8 @@
                 "description": "5分間のみ使用できます。",
                 "link": "リンク"
             },
-            "httpError": "エラーが発生しました: ${0}"
+            "httpError": "エラーが発生しました: ${0}",
+            "generalError": "不明なエラーが発生しました"
         },
         "testx": {
             "name": "dev01",


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
一時リンクのサーバー処理に [TeamSekai/TempLinkSrv](https://github.com/TeamSekai/TempLinkSrv) を使用できるようにしました。
TempLinkSrv を使用する場合、`config.json` に `tempLinkSrvToken` と `tempLinkSrvPostUrl` を追加します。この場合、`linkDomain` と `linkPort` は無視されます。
`tempLinkSrvToken` を `null` とする・定義しない場合、プロセス内でサーバー処理を行います。


## 変更点

<!--- 変更点の記述 -->
* `discordbot.js` 内の TempLink 関連のコードを `internal/templinks.js` へ移動
* `en.json` 内の誤訳を修正 (私のミスです。恥ずかしい)
    ```diff
    - Link: ${id} has generated.
    + Link: ${id} has been generated.
    ```
* `config.json` に `tempLinkSrvToken` が定義されている場合、TempLinkSrv の API を使用するように変更
* 言語を `en` とし、内部 TempLink サーバーを使用しているとき、リンクの埋め込みの表示が崩れる問題を修正


## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
