### PR TITLE
Graceful shutdown

### DIFF
--- a/commands/updater.js
+++ b/commands/updater.js
@@ -4,6 +4,8 @@ const childprocess = require('child_process');
 const path = require("path");
 const color = require("colors");
 const { LANG } = require('../util/languages');
+const { shutdown } = require('../internal/schedules');
+
 module.exports = {
   data: new SlashCommandBuilder()
     .setName(LANG.commands.updater.name)
@@ -47,9 +49,7 @@ module.exports = {
     gitProcess.on("close", async () => {
         clearTimeout(timeout);
         await interaction.editReply("```ansi\n" + msg + "\n```\n" + LANG.commands.updater.restarting.join('\n'));
-        setTimeout(() => {
-            process.exit(0);
-        }, 5000);
+        shutdown();
     })
 
   },

--- a/discordbot.js
+++ b/discordbot.js
@@ -112,6 +112,7 @@ onShutdown(async () => {
 	const SyslogChannel = client.channels.cache.get(syslogChannel);
 	await SyslogChannel.send(LANG.discordbot.shutdown.sysLog);
 	await client.destroy();
+	console.log(cgreen + LANG.discordbot.shutdown.loggedOut + creset);
 });
 
 

--- a/discordbot.js
+++ b/discordbot.js
@@ -12,6 +12,7 @@ process.env["FFMPEG_PATH"] = path.join(__dirname,"ffmpeg")
 const os = require('os');
 
 //!Load Internal dir code
+const { onShutdown } = require('./internal/schedules');
 const activity = require('./internal/activity');
 const mongodb = require('./internal/mongodb');
 
@@ -104,6 +105,13 @@ client.on('ready', async () => {
 	console.log(cgreen + LANG.discordbot.ready.commandsReady + creset);
 	let SyslogChannel = client.channels.cache.get(syslogChannel);
 	SyslogChannel.send(LANG.discordbot.ready.sysLog);
+});
+
+
+onShutdown(async () => {
+	const SyslogChannel = client.channels.cache.get(syslogChannel);
+	await SyslogChannel.send(LANG.discordbot.shutdown.sysLog);
+	await client.destroy();
 });
 
 

--- a/internal/activity.js
+++ b/internal/activity.js
@@ -1,5 +1,6 @@
 const { Client, Events, Intents, Status, ActivityType } = require('discord.js');
 const { LANG, strFormat } = require('../util/languages');
+const { onShutdown } = require('./schedules');
 
 
 console.log(LANG.internal.activity.called);
@@ -26,9 +27,12 @@ function addPingValue(ping) {
   }
   
   module.exports = {
+	/**
+	 * @param {Client<boolean>} client
+	 */
 	setupActivity(client){
 		client.on('ready', async () => {
-			setInterval(() => {
+			const intervalId = setInterval(() => {
 				const wsping = client.ws.ping;
 				addPingValue(wsping)
 				// avg
@@ -41,7 +45,18 @@ function addPingValue(ping) {
 					}],
 					status: `online`,
 				});
-			}, 40000)
+			}, 40000);
+			onShutdown(() => {
+				clearInterval(intervalId);
+				client.user.setPresence({
+					activities: [{
+						name: LANG.internal.activity.presenceNameShuttingDown,
+						state: LANG.internal.activity.presenceStateShuttingDown,
+						type: ActivityType.Watching,
+					}],
+					status: 'idle',
+				})
+			});
 		})
 	},
 	addPingValue,

--- a/internal/mongodb.js
+++ b/internal/mongodb.js
@@ -1,6 +1,7 @@
 const mongoose = require('mongoose');
 const config = require('../config.json');
 const { LANG } = require('../util/languages');
+const { onShutdown } = require('./schedules');
 
 
 console.log(LANG.internal.mongodb.called);
@@ -28,6 +29,8 @@ db.on("disconnecting", function () {
 db.on("disconnected", function () {
     console.log(LANG.internal.mongodb.dbDisconnected);
 });
+
+onShutdown(() => db.close());
 
 module.exports = {
 	connection: db,

--- a/internal/schedules.js
+++ b/internal/schedules.js
@@ -1,0 +1,29 @@
+const { setTimeout } = require('node:timers/promises');
+const { LANG } = require('../util/languages');
+
+/**
+ * @type {(() => (void | Promise<void>))[]}
+ */
+const closeListeners = [];
+
+async function shutdown() {
+    await Promise.all([
+        ...closeListeners.map(closeListener => closeListener()),
+        setTimeout(5000)
+    ]);
+    console.log(LANG.internal.schedules.processExiting);
+    process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+/**
+ * シャットダウン時の処理を追加する。
+ * @param {() => (void | Promise<void>)} task シャットダウン時の処理
+ */
+function onShutdown(task) {
+    closeListeners.push(task);
+}
+
+module.exports = { shutdown, onShutdown };

--- a/language/default.json
+++ b/language/default.json
@@ -22,7 +22,8 @@
             "commandsReady": "Ready!"
         },
         "shutdown": {
-            "sysLog": "Discord.js Bot is shutting down!"
+            "sysLog": "Discord.js Bot is shutting down!",
+            "loggedOut": "Logged out"
         },
         "interactionCreate": {
             "unsupportedCommandError": "${0}というコマンドには対応していません。",

--- a/language/default.json
+++ b/language/default.json
@@ -21,6 +21,9 @@
             "commandsRegistering": "Registering commands...",
             "commandsReady": "Ready!"
         },
+        "shutdown": {
+            "sysLog": "Discord.js Bot is shutting down!"
+        },
         "interactionCreate": {
             "unsupportedCommandError": "${0}というコマンドには対応していません。",
             "commandError": "コマンド実行時にエラーになりました。"
@@ -55,7 +58,9 @@
         "activity": {
             "called": "Called internal activity system",
             "presenceName": "Sekai - Added GlobalBan System",
-            "presenceState": "Ping: ${0}ms | Created by ringoXD"
+            "presenceState": "Ping: ${0}ms | Created by ringoXD",
+            "presenceNameShuttingDown": "Shutting down...",
+            "presenceStateShuttingDown": "Sekai.explode is now shutting down..."
         },
         "mongodb": {
             "called": "Called mongodb internal system.",
@@ -63,6 +68,12 @@
             "dbConnected": "[MongoDB] Connected!",
             "dbDisconnecting": "[MongoDB] Disconnecting...",
             "dbDisconnected": "[MongoDB] Disconnected!"
+        },
+        "schedules": {
+            "processExiting": "プロセスを終了します"
+        },
+        "templinks": {
+            "shutdown": "[TempLink] サーバーを閉じました"
         }
     },
     "common": {

--- a/language/en.json
+++ b/language/en.json
@@ -22,7 +22,8 @@
             "commandsReady": "Ready!"
         },
         "shutdown": {
-            "sysLog": "Discord.js Bot is shutting down!"
+            "sysLog": "Discord.js Bot is shutting down!",
+            "loggedOut": "Logged out"
         },
         "interactionCreate": {
             "unsupportedCommandError": "A command named ${0} is not supported.",

--- a/language/en.json
+++ b/language/en.json
@@ -21,6 +21,9 @@
             "commandsRegistering": "Registering commands...",
             "commandsReady": "Ready!"
         },
+        "shutdown": {
+            "sysLog": "Discord.js Bot is shutting down!"
+        },
         "interactionCreate": {
             "unsupportedCommandError": "A command named ${0} is not supported.",
             "commandError": "An error occurred while executing a command."
@@ -55,7 +58,9 @@
         "activity": {
             "called": "Called internal activity system",
             "presenceName": "Sekai - Added GlobalBan System",
-            "presenceState": "Ping: ${0}ms | Created by ringoXD"
+            "presenceState": "Ping: ${0}ms | Created by ringoXD",
+            "presenceNameShuttingDown": "Shutting down...",
+            "presenceStateShuttingDown": "Sekai.explode is now shutting down..."
         },
         "mongodb": {
             "called": "Called mongodb internal system.",
@@ -63,6 +68,12 @@
             "dbConnected": "[MongoDB] Connected!",
             "dbDisconnecting": "[MongoDB] Disconnecting...",
             "dbDisconnected": "[MongoDB] Disconnected!"
+        },
+        "schedules": {
+            "processExiting": "Exiting the process"
+        },
+        "templinks": {
+            "shutdown": "[TempLink] Server closed"
         }
     },
     "common": {

--- a/language/ja.json
+++ b/language/ja.json
@@ -22,7 +22,8 @@
             "commandsReady": "完了!"
         },
         "shutdown": {
-            "sysLog": "Discord.js Bot を終了しています!"
+            "sysLog": "Discord.js Bot を終了しています!",
+            "loggedOut": "ログアウトしました"
         },
         "interactionCreate": {
             "unsupportedCommandError": "${0}というコマンドには対応していません。",

--- a/language/ja.json
+++ b/language/ja.json
@@ -21,6 +21,9 @@
             "commandsRegistering": "コマンドを登録中…",
             "commandsReady": "完了!"
         },
+        "shutdown": {
+            "sysLog": "Discord.js Bot を終了しています!"
+        },
         "interactionCreate": {
             "unsupportedCommandError": "${0}というコマンドには対応していません。",
             "commandError": "コマンド実行時にエラーになりました。"
@@ -53,9 +56,11 @@
     },
     "internal": {
         "activity": {
-            "called": "内部動作氏システムを呼び出しました",
+            "called": "内部動作システムを呼び出しました",
             "presenceName": "Sekai - GlobalBan システムを追加",
-            "presenceState": "Ping: ${0}ms | Created by ringoXD"
+            "presenceState": "Ping: ${0}ms | Created by ringoXD",
+            "presenceNameShuttingDown": "シャットダウン中…",
+            "presenceStateShuttingDown": "Sekai.explode はシャットダウン中です…"
         },
         "mongodb": {
             "called": "MongoDB 内部システムを呼び出しました。",
@@ -63,6 +68,12 @@
             "dbConnected": "[MongoDB] 接続しました！",
             "dbDisconnecting": "[MongoDB] 切断中…",
             "dbDisconnected": "[MongoDB] 切断しました！"
+        },
+        "schedules": {
+            "processExiting": "プロセスを終了します"
+        },
+        "templinks": {
+            "shutdown": "[TempLink] サーバーを閉じました"
         }
     },
     "common": {


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
プロセスの終了時にリソースを適切に開放するようにしました。

## 変更点

<!--- 変更点の記述 -->
* `internal/schedules.js` ファイルを追加して `shutdown`, `onShutdown` 関数を作成
* /update コマンドが `shutdown` 関数を呼び出すように変更
* SIGINT, SIGTERM シグナルの発生時に `shutdown` 関数を呼び出すように変更
* `onShutdown` 関数を用いてプロセス終了時に以下の動作を追加
  * bot のステータスを「Shutting down...」等に変更
  * Discord bot クライアントのログアウト
  * MongoDB からの切断
  * 内部 TempLink サーバ－を使用している場合、Web サーバーの終了
  * 5 秒待機

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
