### PR TITLE
/pause, /resumeコマンドの追加

### DIFF
--- a/commands/pause.js
+++ b/commands/pause.js
@@ -1,0 +1,34 @@
+// @ts-check
+
+const { SlashCommandBuilder } = require("discord.js");
+const { LANG } = require("../util/languages");
+const { getPlayableVoiceChannelId, getPlayingQueue, saveQueue } = require("../util/players");
+
+/** @type {import("../util/types").Command} */
+const commandPause = {
+    data: new SlashCommandBuilder()
+        .setName(LANG.commands.pause.name)
+        .setDescription(LANG.commands.pause.description),
+
+    async execute(interaction) {
+        if (getPlayableVoiceChannelId(interaction) == null) {
+            await interaction.reply({ content: LANG.common.message.notPlayableError, ephemeral: true });
+            return;
+        }
+
+        const queue = getPlayingQueue(interaction);
+		if (!queue) {
+			await interaction.reply({ content: LANG.common.message.noTracksPlayed, ephemeral: true });
+            return;
+        }
+
+        const success = queue.node.pause();
+        if (success) {
+            await interaction.reply(LANG.commands.pause.playerPaused);
+        } else {
+            await interaction.reply(LANG.commands.pause.pauseFailed);
+        }
+    }
+};
+
+module.exports = commandPause;

--- a/commands/pause.js
+++ b/commands/pause.js
@@ -2,26 +2,14 @@
 
 const { SlashCommandBuilder } = require("discord.js");
 const { LANG } = require("../util/languages");
-const { getPlayableVoiceChannelId, getPlayingQueue } = require("../util/players");
+const { PlayerCommand } = require("../common/PlayerCommand");
 
-/** @type {import("../util/types").Command} */
-const commandPause = {
-    data: new SlashCommandBuilder()
+module.exports = new PlayerCommand(
+    new SlashCommandBuilder()
         .setName(LANG.commands.pause.name)
         .setDescription(LANG.commands.pause.description),
 
-    async execute(interaction) {
-        if (getPlayableVoiceChannelId(interaction) == null) {
-            await interaction.reply({ content: LANG.common.message.notPlayableError, ephemeral: true });
-            return;
-        }
-
-        const queue = getPlayingQueue(interaction);
-        if (!queue) {
-            await interaction.reply({ content: LANG.common.message.noTracksPlayed, ephemeral: true });
-            return;
-        }
-
+    async function(interaction, queue) {
         const success = queue.node.pause();
         if (success) {
             await interaction.reply(LANG.commands.pause.playerPaused);
@@ -29,6 +17,4 @@ const commandPause = {
             await interaction.reply(LANG.commands.pause.pauseFailed);
         }
     }
-};
-
-module.exports = commandPause;
+);

--- a/commands/queue.js
+++ b/commands/queue.js
@@ -1,21 +1,18 @@
+// @ts-check
+
 const { SlashCommandBuilder } = require('discord.js');
 const Pager = require('../util/pager');
-const { getPlayableVoiceChannelId, getPlayingQueue, getDuration } = require('../util/players');
+const { getDuration } = require('../util/players');
 const Timespan = require('../util/timespan');
 const { LANG, strFormat } = require('../util/languages');
+const { PlayerCommand } = require('../common/PlayerCommand');
 
-module.exports = {
-    data: new SlashCommandBuilder()
+module.exports = new PlayerCommand(
+    new SlashCommandBuilder()
         .setName(LANG.commands.queue.name)
         .setDescription(LANG.commands.queue.description),
-    execute: async function (interaction) {
-        if (getPlayableVoiceChannelId(interaction) == null)
-            return await interaction.reply({ content: LANG.common.message.notPlayableError, ephemeral: true });
 
-        const queue = getPlayingQueue(interaction);
-        if (!queue)
-            return await interaction.reply({ content: LANG.common.message.noTracksPlayed, ephemeral: true });
-
+    async function(interaction, queue) {
         const queuedTracks = queue.tracks.toArray();
         const tracks = queuedTracks.map((track, idx) => strFormat(LANG.commands.queue.queueItem, {
             index: '**' + strFormat(LANG.commands.queue.queueIndex, [idx + 1]) + '**',
@@ -43,5 +40,5 @@ module.exports = {
             })
         })
         pager.replyTo(interaction);
-    },
-};
+    }
+);

--- a/commands/resume.js
+++ b/commands/resume.js
@@ -1,14 +1,14 @@
 // @ts-check
 
-const { SlashCommandBuilder } = require("discord.js");
-const { LANG } = require("../util/languages");
-const { getPlayableVoiceChannelId, getPlayingQueue } = require("../util/players");
+const { SlashCommandBuilder } = require('discord.js');
+const { LANG } = require('../util/languages');
+const { getPlayableVoiceChannelId, getPlayingQueue } = require('../util/players');
 
 /** @type {import("../util/types").Command} */
-const commandPause = {
+const commandResume = {
     data: new SlashCommandBuilder()
-        .setName(LANG.commands.pause.name)
-        .setDescription(LANG.commands.pause.description),
+        .setName(LANG.commands.resume.name)
+        .setDescription(LANG.commands.resume.description),
 
     async execute(interaction) {
         if (getPlayableVoiceChannelId(interaction) == null) {
@@ -22,13 +22,13 @@ const commandPause = {
             return;
         }
 
-        const success = queue.node.pause();
+        const success = queue.node.resume();
         if (success) {
-            await interaction.reply(LANG.commands.pause.playerPaused);
+            await interaction.reply(LANG.commands.resume.playerResumed);
         } else {
-            await interaction.reply(LANG.commands.pause.pauseFailed);
+            await interaction.reply(LANG.commands.resume.resumeFailed);
         }
     }
 };
 
-module.exports = commandPause;
+module.exports = commandResume;

--- a/commands/stop.js
+++ b/commands/stop.js
@@ -1,20 +1,16 @@
-const { SlashCommandBuilder } = require('discord.js');
-const { getPlayableVoiceChannelId, getPlayingQueue } = require('../util/players');
-const { LANG } = require('../util/languages');
+// @ts-check
 
-module.exports = {
-    data: new SlashCommandBuilder()
+const { SlashCommandBuilder } = require('discord.js');
+const { LANG } = require('../util/languages');
+const { PlayerCommand } = require('../common/PlayerCommand');
+
+module.exports = new PlayerCommand(
+    new SlashCommandBuilder()
         .setName(LANG.commands.stop.name)
         .setDescription(LANG.commands.stop.description),
-    execute: async function (interaction) {
-        if (getPlayableVoiceChannelId(interaction) == null) 
-            return await interaction.reply({ content: LANG.common.message.notPlayableError, ephemeral: true });
 
-        const queue = getPlayingQueue(interaction);
-		if (!queue)
-			return await interaction.reply({ content: LANG.common.message.noTracksPlayed, ephemeral: true });
-
+    async function(interaction, queue) {
         queue.delete();
         await interaction.reply(LANG.commands.stop.playerStopped);
     }
-};
+);

--- a/common/PlayerCommand.js
+++ b/common/PlayerCommand.js
@@ -1,0 +1,59 @@
+// @ts-check
+
+const { CommandInteraction, SlashCommandBuilder } = require('discord.js');
+const { getPlayableVoiceChannelId, getPlayingQueue } = require('../util/players');
+const { LANG } = require('../util/languages');
+const { GuildQueue } = require('discord-player');
+
+/**
+ * @typedef {import("../util/types").Command} Command
+ */
+
+/**
+ * @typedef {import('../util/players').QueueMetadata} QueueMetadata
+ */
+
+/**
+ * 音楽プレイヤーの操作を行うコマンド。
+ * コマンドを実行したユーザーがボイスチャンネルに参加していて、
+ * かつ音楽が再生されている場合に action 関数を呼び出す。
+ * @implements {Command}
+ */
+class PlayerCommand {
+    data;
+
+    action;
+
+    /**
+     * 
+     * @param {SlashCommandBuilder} data
+     * @param {(interaction: CommandInteraction,
+     *          queue: GuildQueue<QueueMetadata>,
+     *          voiceChannelId: string) => Promise<void>} action 音楽プレイヤーの操作。チェックを行った後に呼び出される。
+     */
+    constructor(data, action) {
+        this.data = data;
+        this.action = action;
+    }
+
+    /**
+     * @param {CommandInteraction} interaction
+     */
+    async execute(interaction) {
+        const voiceChannelId = getPlayableVoiceChannelId(interaction);
+        if (voiceChannelId == null) {
+            await interaction.reply({ content: LANG.common.message.notPlayableError, ephemeral: true });
+            return;
+        }
+
+        const queue = getPlayingQueue(interaction);
+        if (!queue) {
+            await interaction.reply({ content: LANG.common.message.noTracksPlayed, ephemeral: true });
+            return;
+        }
+
+        this.action(interaction, queue, voiceChannelId);
+    }
+}
+
+module.exports = { PlayerCommand };

--- a/language/default.json
+++ b/language/default.json
@@ -422,6 +422,12 @@
             "greatGoodLuck": "大吉",
             "assertionError": "エラー(function result: ${0}) - ボットが燃えました"
         },
+        "pause": {
+            "name": "pause",
+            "description": "音楽を一時停止します。",
+            "playerPaused": "音楽を一時停止しました！",
+            "pauseFailed": "一時停止できませんでした"
+        },
         "pieChart": {
             "name": "piechart",
             "description": "円グラフを生成します。",

--- a/language/default.json
+++ b/language/default.json
@@ -495,6 +495,12 @@
                 "footer": "実行者: ${0}"
             }
         },
+        "resume": {
+            "name": "resume",
+            "description": "音楽の再生を再開します",
+            "playerResumed": "音楽を再生します！",
+            "resumeFailed": "音楽を再生できませんでした"
+        },
         "skip": {
             "name": "skip",
             "description": "音楽をスキップします！",

--- a/language/en.json
+++ b/language/en.json
@@ -422,6 +422,12 @@
             "greatGoodLuck": "Great good luck",
             "assertionError": "Error(function result: ${0}) - The bot has gone up into flames"
         },
+        "pause": {
+            "name": "pause",
+            "description": "Pauses the player",
+            "playerPaused": "Paused the player!",
+            "pauseFailed": "Failed to pause the player"
+        },
         "pieChart": {
             "name": "piechart",
             "description": "Generates a pie chart.",
@@ -488,6 +494,12 @@
                 "description": "Minimum value: ${min}, Maximum value: ${max}",
                 "footer": "Executed by: ${0}"
             }
+        },
+        "resume": {
+            "name": "resume",
+            "description": "Resumes the player",
+            "playerResumed": "Resuming the player!",
+            "resumeFailed": "Failed to resume the player"
         },
         "skip": {
             "name": "skip",

--- a/language/ja.json
+++ b/language/ja.json
@@ -422,6 +422,12 @@
             "greatGoodLuck": "大吉",
             "assertionError": "エラー(関数の結果: ${0}) - ボットが燃えました"
         },
+        "pause": {
+            "name": "pause",
+            "description": "音楽を一時停止します。",
+            "playerPaused": "音楽を一時停止しました！",
+            "pauseFailed": "一時停止できませんでした"
+        },
         "pieChart": {
             "name": "piechart",
             "description": "円グラフを生成します。",
@@ -488,6 +494,12 @@
                 "description": "最小値: ${min}, 最大値: ${max}",
                 "footer": "実行者: ${0}"
             }
+        },
+        "resume": {
+            "name": "resume",
+            "description": "音楽の再生を再開します",
+            "playerResumed": "音楽を再生します！",
+            "resumeFailed": "音楽を再生できませんでした"
         },
         "skip": {
             "name": "skip",

--- a/util/assertion.js
+++ b/util/assertion.js
@@ -1,0 +1,19 @@
+// @ts-check
+
+/**
+ * アサーションが失敗したときに投げる例外。
+ */
+class AssertionError extends Error {
+    static {
+        AssertionError.prototype.name = 'AssertionError';
+    }
+
+    /**
+     * @param {string=} message
+     */
+    constructor(message) {
+        super(message);
+    }
+}
+
+module.exports = { AssertionError };

--- a/util/pager.js
+++ b/util/pager.js
@@ -1,4 +1,4 @@
-const { EmbedBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder } = require('discord.js');
+const { EmbedBuilder, ButtonBuilder, ButtonStyle, ActionRowBuilder, BaseInteraction } = require('discord.js');
 
 /**
  * @typedef {Object} OptionSet Pager のコンストラクタに渡すことができるオプション
@@ -230,7 +230,7 @@ class Pager {
 
     /**
      * この Pager をリプライとして表示する。
-     * @param {import("discord.js").Interaction<import("discord.js").CacheType} interaction 対話オブジェクト
+     * @param {BaseInteraction} interaction 対話オブジェクト
      */
     async replyTo(interaction) {
         if (!interaction.isRepliable()) {

--- a/util/players.js
+++ b/util/players.js
@@ -192,13 +192,13 @@ const functions = {
         const volume = await functions.loadVolumeSetting(guild);
         return {
             metadata,
-            bufferingTimeout: 15000,
+            bufferingTimeout: 15_000,
             leaveOnStop: true,
-            leaveOnStopCooldown: 5000,
+            leaveOnStopCooldown: 5_000,
             leaveOnEnd: true,
-            leaveOnEndCooldown: 15000,
+            leaveOnEndCooldown: 15_000,
             leaveOnEmpty: true,
-            leaveOnEmptyCooldown: 1000, // 300_000 に戻す
+            leaveOnEmptyCooldown: 300_000,
             volume
         }
     },

--- a/util/types.js
+++ b/util/types.js
@@ -1,0 +1,11 @@
+// @ts-check
+
+// 汎用的な型を定義するファイル
+
+const { SlashCommandBuilder, CommandInteraction } = require("discord.js");
+
+/**
+ * @typedef {Object} Command スラッシュコマンドを表すオブジェクト
+ * @property {SlashCommandBuilder} data Discord の API に登録するデータ
+ * @property {(interaction: CommandInteraction) => Promise<void>} execute コマンドの処理
+ */


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
音楽を一時停止する /pause コマンド、音楽の再生を再開する /resume コマンドを追加しました。

## 変更点

<!--- 変更点の記述 -->
- メンバーが抜けてからプレイヤーを終了するまでのクールタイムを元通りに
- /pause コマンドの追加
- /resume コマンドの追加
- プレイヤー操作のコマンドを抽象化する PlayerCommand クラスを作成

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
