### PR TITLE
にゃんぱすーカウントの取得 (#17)

### DIFF
--- a/commands/nyanpass.js
+++ b/commands/nyanpass.js
@@ -1,0 +1,64 @@
+// @ts-check
+
+const { SlashCommandBuilder, EmbedBuilder, ButtonBuilder, ActionRowBuilder, ButtonStyle } = require('discord.js');
+const { LANG, strFormat } = require('../util/languages');
+const axios = require('axios').default
+
+/**
+ * @typedef {Object} NyanpassData
+ * @property {string} time
+ * @property {string} count
+ */
+
+let axiosNyanpass;
+
+async function getNyanpass() {
+    /** @type {import('axios').AxiosResponse<NyanpassData>} */
+    const res = await axios.get('https://nyanpass.com/api/get_count');
+    return res.data;
+}
+
+/**
+ * 
+ * @returns {Promise<import('discord.js').InteractionReplyOptions>}
+ */
+async function createReply() {
+    const { time, count } = await getNyanpass();
+    const embed = new EmbedBuilder()
+        .setTitle(LANG.commands.nyanpass.title)
+        .setColor(0xe75297)
+        .setDescription('```' + count.padStart(15) + '```')
+        .setFooter({
+            text: strFormat(LANG.commands.nyanpass.footer, [time])
+        });
+    const component = new ButtonBuilder()
+        .setStyle(ButtonStyle.Link)
+        .setEmoji('✋')
+        .setLabel(LANG.commands.nyanpass.button)
+        .setURL('https://nyanpass.com/')
+    /** @type {ActionRowBuilder<ButtonBuilder>} */
+    const row = new ActionRowBuilder();
+    row.addComponents(component);
+    return {
+        embeds: [embed],
+        components: [row]
+    };
+}
+
+/** @type {import("../util/types").Command} */
+const commandNyanpass = {
+    data: new SlashCommandBuilder()
+        .setName(LANG.commands.nyanpass.name)
+        .setDescription(LANG.commands.nyanpass.description),
+
+    async execute(interaction) {
+        const firstNyanpass = await getNyanpass();
+        await interaction.reply(await createReply());
+        const interval = setInterval(async () => {
+            await interaction.editReply(await createReply());
+        }, 3_000);
+        setTimeout(() => clearInterval(interval), 60_000);
+    }
+};
+
+module.exports = commandNyanpass;

--- a/language/default.json
+++ b/language/default.json
@@ -344,6 +344,13 @@
                 "footer": "Sekai.Explode"
             }
         },
+        "nyanpass": {
+            "name": "nyanpass",
+            "description": "にゃんぱすーカウントを取得",
+            "title": "にゃんぱすーカウント",
+            "footer": "${0} 時点",
+            "button": "にゃんぱすーボタン"
+        },
         "nettool": {
             "name": "net_tool",
             "description": "ネットワーク関連のコマンド",

--- a/language/en.json
+++ b/language/en.json
@@ -344,6 +344,13 @@
                 "footer": "Sekai.Explode"
             }
         },
+        "nyanpass": {
+            "name": "nyanpass",
+            "description": "Gets Nyanpass count",
+            "title": "Nyanpass Count",
+            "footer": "as of ${0}",
+            "button": "Nyanpass Button"
+        },
         "nettool": {
             "name": "net_tool",
             "description": "A command related with networks",

--- a/language/ja.json
+++ b/language/ja.json
@@ -344,6 +344,13 @@
                 "footer": "Sekai.Explode"
             }
         },
+        "nyanpass": {
+            "name": "nyanpass",
+            "description": "にゃんぱすーカウントを取得",
+            "title": "にゃんぱすーカウント",
+            "footer": "${0} 時点",
+            "button": "にゃんぱすーボタン"
+        },
         "nettool": {
             "name": "net_tool",
             "description": "ネットワーク関連のコマンド",


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
#17 の実装。
にゃんぱすーカウントを取得する /nyanpass コマンドを追加。
このコマンドを実行すると1分間、3秒おきに https://nyanpass.com/api/get_count の内容を取得します。

## 変更点

<!--- 変更点の記述 -->
- `commands/nyanpass.js` で /nyanpass コマンドを作成

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
