### PR TITLE
/adminを乗っ取るコマンドのメッセージを修正

### DIFF
--- a/commands/fake.js
+++ b/commands/fake.js
@@ -15,7 +15,7 @@ module.exports = [
             .setName(LANG.commands.fake.hackAdmin.name)
             .setDescription(LANG.commands.fake.hackAdmin.description),
         execute: async function (interaction) {
-            await interaction.reply(strFormat(LANG.commands.fake.hackAdmin.message, `[${LANG.commands.fake.hackAdmin.linkText}](${rickurl})`));
+            await interaction.reply(strFormat(LANG.commands.fake.hackAdmin.message, [`[${LANG.commands.fake.hackAdmin.linkText}](${rickurl})`]));
         },
     }
 ];


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
/adminを乗っ取るコマンドのリンクとなるべきところが「[」となり、リンクが張られていなかったので、修正しました。

## 変更点

<!--- 変更点の記述 -->
- /adminを乗っ取るコマンドのメッセージを生成する関数の引数が配列になっていなかったので修正

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
