### PR TITLE
`strFormat` 関数の機能強化 (#39)

### DIFF
--- a/util/languages.js
+++ b/util/languages.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const path = require('path');
 const config = require('../config.json');
 const LANG = require('../language/default.json');
@@ -30,17 +32,13 @@ class FormatSyntaxError extends SyntaxError {
     }
 }
 
-// enum like in Java?!
-/**
- * @enum {State} format 関数で用いる有限オートマトンの状態。
- */
-class State {
-    constructor() {}
-    static PLAIN = new State();
-    static ESCAPED = new State();
-    static AFTER_DOLLAR = new State();
-    static IN_PLACEHOLDER = new State();
-}
+/** @enum {number} format 関数で用いる有限オートマトンの状態。 */
+const State = {
+    PLAIN: 0,
+    ESCAPED: 1,
+    AFTER_DOLLAR: 2,
+    IN_PLACEHOLDER: 3
+};
 
 /**
  * 文字列中のプレースホルダを指定された値で置き換える。
@@ -60,9 +58,9 @@ class State {
  * ```
  * 
  * @param {string} str 文字列のフォーマット
- * @param {Object=} values プレースホルダを置き換える値
+ * @param {Object=} map プレースホルダを置き換える値
  */
-function strFormat(str, values) {
+function strFormat(str, map) {
     let result = '';
     let placeholder = '';
 
@@ -99,7 +97,7 @@ function strFormat(str, values) {
                 break;
             case State.IN_PLACEHOLDER:
                 if (c == '}') {
-                    result += values?.[placeholder.trim()];
+                    result += map?.[placeholder.trim()];
                     placeholder = '';
                     state = State.PLAIN;
                 } else {

--- a/util/languages.js
+++ b/util/languages.js
@@ -44,23 +44,30 @@ const State = {
  * 文字列中のプレースホルダを指定された値で置き換える。
  * 
  * `str` は `"${"` と `"}"` に囲まれたプレースホルダを含むことができる。
- * 文字列 `placeholder` について、 `str` 中の `"${" + placeholder + "}"` は
+ * 文字列 `placeholder` について、
+ * values の要素数が 1 であり、その要素が Object であるとき、
+ * `str` 中の `"${" + placeholder + "}"` は
+ * `values[0]?.[placeholder.trim()]` に置き換えられる。
+ * values の要素が複数個であるか、Object でない要素が含まれるとき、
  * `values?.[placeholder.trim()]` に置き換えられる。
  * ただし、`placeholder.trim()` は `placeholder` の先頭と末尾の空白文字を除いた文字列である。
  * プレースホルダ外において、`"\\\\""`, `"\\$", `"\\{" はそれぞれ `"\\"`, `"$"`, `"{"` に置き換えられる。
  * 
  * 例:
  * ```
- * format("text ${a} abc", { a: 123 });    // == "text 123 abc"
- * format("text ${ a } abc", { a: 123 });  // == "text 123 abc"
- * format("text \\${a} abc", { a: 123 });  // == "text ${a} abc"
- * format("text $\\{a} abc", { a: 123 });  // == "text ${a} abc"
+ * strFormat("text ${a} abc", { a: 123 });    // == "text 123 abc"
+ * strFormat("text ${ a } abc", { a: 123 });  // == "text 123 abc"
+ * strFormat("text \\${a} abc", { a: 123 });  // == "text ${a} abc"
+ * strFormat("text $\\{a} abc", { a: 123 });  // == "text ${a} abc"
+ * strFormat("text ${0} abc", [123]);         // == "text 123 abc"
+ * strFormat("text ${0} abc", 123);           // == "text 123 abc"
  * ```
  * 
  * @param {string} str 文字列のフォーマット
- * @param {Object=} map プレースホルダを置き換える値
+ * @param {unknown[]} values プレースホルダを置き換える値
  */
-function strFormat(str, map) {
+function strFormat(str, ...values) {
+    const map = toMap(values);
     let result = '';
     let placeholder = '';
 
@@ -113,6 +120,19 @@ function strFormat(str, map) {
         throw new FormatSyntaxError("Unexpected end of input; '}' expected")
 
     return result;
+}
+
+/**
+ * @param  {unknown[]} values
+ */
+function toMap(values) {
+    if (values.length == 0) {
+        return null;
+    }
+    if (values.length == 1 && values[0] instanceof Object) {
+        return values[0];
+    }
+    return values;
 }
 
 module.exports = { LANG, FormatSyntaxError, strFormat, assignDeep };

--- a/util/languages.test.js
+++ b/util/languages.test.js
@@ -51,4 +51,6 @@ test('strFormat', () => {
     expect(strFormat("ab\\")).toBe("ab\\");
     expect(strFormat("ab\\c")).toBe("ab\\c");
     expect(() => strFormat("abc${key")).toThrow(FormatSyntaxError);
+    expect(strFormat("text ${0} abc", [123])).toBe("text 123 abc");
+    expect(strFormat("text ${0} abc", 123)).toBe("text 123 abc");
 });


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
#39 に関連して、`strFormat` に与えられた第2引数がオブジェクトでない場合に意図した動作をするように変更しました。

## 変更点

<!--- 変更点の記述 -->
- `strFormat` の第2引数がオブジェクトで無い場合、第2引数以降を配列として扱うように変更

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
