### PR TITLE
/follow_announcementsの権限調整(#43)

### DIFF
--- a/commands/receiveupdate.js
+++ b/commands/receiveupdate.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, ChannelType } = require('discord.js');
+const { SlashCommandBuilder, ChannelType, PermissionsBitField } = require('discord.js');
 const config = require('../config.json')
 const { LANG } = require('../util/languages');
 
@@ -14,6 +14,9 @@ module.exports = {
 			.setRequired(true)
 		),
     execute: async function (interaction, client) {
+		if (!interaction.member.permissions.has(PermissionsBitField.Flags.Administrator)) {
+			return await interaction.reply('権限がありません!(管理者権限が必要です。)')
+		}
 		const targetchannel = interaction.options.getChannel('channel');
 		client.channels.resolve("1211695901760819281").addFollower(targetchannel.id) //TODO: config.jsonで編集可能に?
 			.then(() =>


### PR DESCRIPTION
## 内容
#43 のためのPull Requestです。

このPRにより、`/follow_annoucements`が管理者権限を持つユーザーのみ使用可能になります。
## 変更点
* コマンド実行時に権限を確認し、管理者権限がない場合はエラーメッセージを返すように変更

## チェックリスト:

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
