### PR TITLE
自動応答のカスタマイズ (#35)

### DIFF
--- a/commands/reply.js
+++ b/commands/reply.js
@@ -35,8 +35,8 @@ const commandReply = {
                 .setDescription(LANG.commands.reply.subcommands.remove.description)
                 .addStringOption(option =>
                     option
-                        .setName(LANG.commands.reply.subcommands.remove.name)
-                        .setDescription(LANG.commands.reply.subcommands.remove.description)
+                        .setName(LANG.commands.reply.subcommands.remove.options.message.name)
+                        .setDescription(LANG.commands.reply.subcommands.remove.options.message.description)
                         .setRequired(true)))
         .addSubcommand(subcommand =>
             subcommand
@@ -57,7 +57,7 @@ const commandReply = {
         const guildMessageHandler = clientMessageHandler.getGuildMessageHandler(guild.id);
 
         switch (subcommand) {
-            case LANG.commands.reply.subcommands.add.name:
+            case LANG.commands.reply.subcommands.add.name: {
                 const replyPattern = new ReplyPattern(
                     interaction.options.getString(LANG.commands.reply.subcommands.add.options.message.name, true),
                     interaction.options.getString(LANG.commands.reply.subcommands.add.options.reply.name, true),
@@ -73,7 +73,23 @@ const commandReply = {
                     });
                 }
                 return;
-            case LANG.commands.reply.subcommands.remove.name:
+            }
+
+            case LANG.commands.reply.subcommands.remove.name: {
+                const replyPattern = await guildMessageHandler.removeReplyPattern(
+                    interaction.options.getString(LANG.commands.reply.subcommands.remove.options.message.name, true)
+                );
+                if (replyPattern != null) {
+                    await interaction.reply(LANG.commands.reply.subcommands.remove.succeeded + '\n' + replyPattern);
+                } else {
+                    await interaction.reply({
+                        content: LANG.commands.reply.subcommands.remove.doNotExist,
+                        ephemeral: true,
+                    });
+                }
+                return;
+            }
+
             case LANG.commands.reply.subcommands.list.name:
             default:
                 assert.fail(subcommand);

--- a/commands/reply.js
+++ b/commands/reply.js
@@ -4,6 +4,7 @@ const assert = require('assert');
 const { SlashCommandBuilder } = require("discord.js");
 const { LANG } = require("../util/languages");
 const { ClientMessageHandler, ReplyPattern } = require("../internal/messages");
+const Pager = require('../util/pager');
 
 /** @type {import("../util/types").Command} */
 const commandReply = {
@@ -90,7 +91,17 @@ const commandReply = {
                 return;
             }
 
-            case LANG.commands.reply.subcommands.list.name:
+            case LANG.commands.reply.subcommands.list.name: {
+                const replyPatterns = await guildMessageHandler.getReplyPatterns();
+                const pager = new Pager(replyPatterns.map(pattern => `- ${pattern}`), {
+                    title: '自動応答メッセージ',
+                    color: 'Green',
+                    emptyMessage: 'メッセージが設定されていません'
+                });
+                await pager.replyTo(interaction);
+                return;
+            }
+
             default:
                 assert.fail(subcommand);
         }

--- a/commands/reply.js
+++ b/commands/reply.js
@@ -28,11 +28,6 @@ const commandReply = {
                     option
                         .setName(LANG.commands.reply.subcommands.add.options.perfectMatching.name)
                         .setDescription(LANG.commands.reply.subcommands.add.options.perfectMatching.description)
-                        .setRequired(false))
-                .addBooleanOption(option =>
-                    option
-                        .setName(LANG.commands.reply.subcommands.add.options.regularExpression.name)
-                        .setDescription(LANG.commands.reply.subcommands.add.options.regularExpression.description)
                         .setRequired(false)))
         .addSubcommand(subcommand =>
             subcommand

--- a/commands/reply.js
+++ b/commands/reply.js
@@ -1,0 +1,54 @@
+// @ts-check
+
+const { SlashCommandBuilder } = require("discord.js");
+const { LANG } = require("../util/languages");
+
+/** @type {import("../util/types").Command} */
+const commandReply = {
+    data: new SlashCommandBuilder()
+        .setName(LANG.commands.reply.name)
+        .setDescription(LANG.commands.reply.description)
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName(LANG.commands.reply.subcommands.add.name)
+                .setDescription(LANG.commands.reply.subcommands.add.description)
+                .addStringOption(option =>
+                    option
+                        .setName(LANG.commands.reply.subcommands.add.options.message.name)
+                        .setDescription(LANG.commands.reply.subcommands.add.options.message.description)
+                        .setRequired(true))
+                .addStringOption(option =>
+                    option
+                        .setName(LANG.commands.reply.subcommands.add.options.reply.name)
+                        .setDescription(LANG.commands.reply.subcommands.add.options.reply.description)
+                        .setRequired(true))
+                .addBooleanOption(option =>
+                    option
+                        .setName(LANG.commands.reply.subcommands.add.options.perfectMatching.name)
+                        .setDescription(LANG.commands.reply.subcommands.add.options.perfectMatching.description)
+                        .setRequired(false))
+                .addBooleanOption(option =>
+                    option
+                        .setName(LANG.commands.reply.subcommands.add.options.regularExpression.name)
+                        .setDescription(LANG.commands.reply.subcommands.add.options.regularExpression.description)
+                        .setRequired(false)))
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName(LANG.commands.reply.subcommands.remove.name)
+                .setDescription(LANG.commands.reply.subcommands.remove.description)
+                .addStringOption(option =>
+                    option
+                        .setName(LANG.commands.reply.subcommands.remove.name)
+                        .setDescription(LANG.commands.reply.subcommands.remove.description)
+                        .setRequired(true)))
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName(LANG.commands.reply.subcommands.list.name)
+                .setDescription(LANG.commands.reply.subcommands.list.description)),
+
+    async execute(interaction) {
+        interaction.reply('This command is in developing!');
+    }
+};
+
+module.exports = commandReply;

--- a/discordbot.js
+++ b/discordbot.js
@@ -5,7 +5,6 @@ const fs = require("fs");
 const path = require("path");
 const { token, syslogChannel } = require('./config.json');
 const { enableTempLinks } = require('./internal/templinks');
-const axios = require('axios');
 const { Player } = require('discord-player');
 const internal = require('stream');
 process.env["FFMPEG_PATH"] = path.join(__dirname,"ffmpeg")
@@ -37,21 +36,6 @@ let oWrite2 = process.stdout.write;
 process.stderr.write = function () {
     oWrite2.apply(this, arguments);
     fs.appendFileSync("discordbot.log", arguments[0] || "")
-}
-//!function
-async function getRedirectUrl(shortUrl) {
-    try {
-        const response = await axios.head(shortUrl, {
-			maxRedirects: 0,
-			 validateStatus: (status) => status == 301 || status == 302
-		});
-        const redirectUrl = response.headers.location;
-        console.log(LANG.discordbot.getRedirectUrl.redirectURL, redirectUrl);
-        return redirectUrl;
-    } catch (error) {
-        console.error(LANG.discordbot.getRedirectUrl.error, error.message);
-		return `${LANG.discordbot.getRedirectUrl.error} ${error.message}`
-    }
 }
 
 //!RUN=======================
@@ -154,89 +138,7 @@ client.login(token);
 
 
 client.on('messageCreate', async (message) => {
-    if (message.author.bot) return;
-
-	const done = await messageHandler?.handleMessage(message);
-	if (done) {
-		return;
-	}
-
-    const urls = message.content.match(/https?:\/\/[^\s]+/g);
-
-    if (urls) {
-        for (let url of urls) {
-            if (url.includes('twitter.com') || url.includes('x.com')) {
-				if (url.includes('vxtwitter.com') || url.includes('fxtwitter.com')) { //ignore vxtwitter.com and fxtwitter.com
-					return;
-				}
-                await message.react('🔗'); // リアクションを追加
-
-				const filter = (reaction, user) => user.id == message.author.id && reaction.emoji.name === '🔗';
-                const collector = message.createReactionCollector({ filter, time: 30000 });
-
-                collector.on('collect', async (reaction, user) => {
-                    const modifiedURL = url.replace('twitter.com', 'vxtwitter.com').replace('x.com', 'vxtwitter.com');
-					let fxmsg = strFormat(LANG.discordbot.messageCreate.requestedBy, [user.username]) + `\n${modifiedURL}`;
-					message.channel.send(fxmsg)
-						.then(sentmsg => {
-							message.reactions.removeAll().catch(e => {
-								console.error(strFormat(LANG.discordbot.messageCreate.reactionRemoveErrorConsole, [e.code]));
-								let errmsg = '\n' + strFormat(LANG.discordbot.messageCreate.reactionRemoveError, [e.code]);
-								sentmsg.edit(`${fxmsg}${errmsg}`);
-							})
-						})
-		
-					collector.stop();
-                });
-
-                collector.on('end', (collected, reason) => {
-                    if (reason === 'time') {
-                        // TIMEOUT
-                        message.reactions.removeAll();
-                    }
-                });
-            }
-			if (url.includes('vt.tiktok.com') || url.includes('www.tiktok.com')) {
-				if (url.includes('vxtiktok.com')) { 
-					return;
-				}
-                await message.react('🔗'); // リアクションを追加
-
-				const filter = (reaction, user) => user.id == message.author.id && reaction.emoji.name === '🔗';
-                const collector = message.createReactionCollector({ filter, time: 30000 });
-
-                collector.on('collect', async (reaction, user) => {
-					console.log(strFormat(LANG.discordbot.messageCreate.beforeUrl, [url]));
-					if (url.includes('vt.tiktok.com')) {
-						url = await getRedirectUrl(url);
-					}
-					console.log(strFormat(LANG.discordbot.messageCreate.afterUrl, [url]));
-					if (url.includes('Error')) {
-						message.channel.send(LANG.discordbot.messageCreate.processError + "\n" + "```" + url + "\n```")
-					}
-                    const modifiedURL = url.replace('www.tiktok.com', 'vxtiktok.com');
-					let fxmsg = strFormat(LANG.discordbot.messageCreate.requestedBy, [user.username]) + `\n${modifiedURL}`;
-					message.channel.send(fxmsg)
-						.then(sentmsg => {
-							message.reactions.removeAll().catch(e => {
-								console.error(strFormat(LANG.discordbot.messageCreate.reactionRemoveErrorConsole, [e.code]));
-								let errmsg = '\n' + strFormat(LANG.discordbot.messageReply.reactionRemoveError, [e.code]);
-								sentmsg.edit(`${fxmsg}${errmsg}`);
-							})
-						})
-		
-					collector.stop();
-                });
-
-                collector.on('end', (collected, reason) => {
-                    if (reason === 'time') {
-                        // TIMEOUT
-                        message.reactions.removeAll();
-                    }
-                });
-            }
-        }
-    }
+	await messageHandler?.handleMessage(message);
 });
 
 

--- a/discordbot.js
+++ b/discordbot.js
@@ -137,9 +137,7 @@ client.login(token);
 
 
 
-client.on('messageCreate', async (message) => {
-	await messageHandler?.handleMessage(message);
-});
+client.on('messageCreate', (message) => messageHandler?.handleMessage(message));
 
 
 //!EVENTS

--- a/internal/messages.js
+++ b/internal/messages.js
@@ -1,0 +1,173 @@
+// @ts-check
+
+/**
+ * このファイルではクライアントが受け取ったメッセージに対して処理を行う。
+ *
+ * このファイルの内容:
+ * - クラス {@link ReplyPattern}
+ * - クラス {@link GuildMessageHandler}
+ * - クラス {@link ClientMessageHandler}
+ *
+ * client.on('messageCreate', ...) において受け取ったメッセージは
+ * {@link ClientMessageHandler#handleMessage} に渡され、
+ * そのメッセージがサーバー内で送られていた場合、さらに対応する {@link GuildMessageHandler} の
+ * {@link GuildMessageHandler#handleMessage} に渡される。
+ * 
+ * メッセージに対して共通の処理は {@link ClientMessageHandler#handleMessage}、
+ * サーバー毎の処理は {@link GuildMessageHandler#handleMessage} において行われる。
+ */
+
+const { Client, Message } = require("discord.js");
+
+/**
+ * 自動応答のパターン。
+ */
+class ReplyPattern {
+    /**
+     * @readonly
+     * @type {string}
+     */
+    messagePattern;
+
+    /**
+     * @readonly
+     * @type {string}
+     */
+    reply;
+
+    /**
+     * @readonly
+     * @type {boolean}
+     */
+    perfectMatching;
+
+    /**
+     * @param {string} messagePattern 反応するメッセージ内容
+     * @param {string} reply 返信内容
+     * @param {boolean=} perfectMatching 完全一致する必要があるか
+     */
+    constructor(messagePattern, reply, perfectMatching = false) {
+        this.messagePattern = messagePattern;
+        this.reply = reply;
+        this.perfectMatching = perfectMatching
+    }
+
+    /**
+     * メッセージ内容がこのパターンに一致するかを調べ、一致する場合は返信内容を返す。
+     * @param {string} message メッセージ内容
+     * @returns メッセージ内容がパターンに一致する場合は返信内容、一致しなければ null
+     */
+    apply(message) {
+        if (this.perfectMatching) {
+            if (message == this.messagePattern) {
+                return this.reply;
+            }
+        } else {
+            if (message.includes(this.messagePattern)) {
+                return this.reply;
+            }
+        }
+        return null;
+    }
+}
+
+/**
+ * サーバーのメッセージに対して処理を行うオブジェクト。
+ */
+class GuildMessageHandler {
+    /**
+     * @readonly
+     * @type {Client<true>}
+     */
+    client;
+
+    /**
+     * @readonly
+     * @type {string}
+     */
+    guildId;
+
+    /**
+     * @type {ReplyPattern[]}
+     */
+    replyPatterns = [new ReplyPattern('それはそう', 'https://soreha.so/')];
+
+    /**
+     * @param {Client<true>} client ログイン済みのクライアント
+     * @param {string} guildId サーバー ID
+     */
+    constructor(client, guildId) {
+        this.client = client;
+        this.guildId = guildId;
+    }
+
+    /**
+     * サーバー内でメッセージを受け取ったときの処理。
+     * @param {Message} message メッセージ
+     * @returns {Promise<boolean>} メッセージに反応したかどうか
+     */
+    async handleMessage(message) {
+        const messageContent = message.content;
+        for (const replyPattern of this.replyPatterns) {
+            const replyContent = replyPattern.apply(messageContent);
+            if (replyContent != null) {
+                await message.reply(replyContent);
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+/**
+ * クライアントが受け取ったメッセージに対して処理を行うオブジェクト。
+ */
+class ClientMessageHandler {
+    /**
+     * @readonly
+     * @type {Client<true>}
+     */
+    client;
+
+    /**
+     * @type {Map<string, GuildMessageHandler>}
+     */
+    guildMessageHandlerMap = new Map();
+
+    /**
+     * @param {Client<true>} client ログイン済みのクライアント
+     */
+    constructor(client) {
+        this.client = client;
+    }
+
+    /**
+     * サーバーに対応する {@link GuildMessageHandler} を取得するか、存在しない場合は新規に作成する。
+     * @param {string} guildId サーバー ID
+     */
+    getGuildMessageHandler(guildId) {
+        const guildMessageHandlerMap = this.guildMessageHandlerMap;
+        const existing = guildMessageHandlerMap.get(guildId);
+        if (existing != null) {
+            return existing;
+        }
+        const created = new GuildMessageHandler(this.client, guildId);
+        guildMessageHandlerMap.set(guildId, created);
+        return created;
+    }
+
+    /**
+     * メッセージを受け取ったときの処理。
+     * @param {Message} message メッセージ
+     * @returns {Promise<boolean>} メッセージに反応したかどうか
+     */
+    async handleMessage(message) {
+        const guild = message.guild;
+        if (guild == null) {
+            return false;
+        }
+        return this.getGuildMessageHandler(guild.id).handleMessage(message);
+    }
+}
+
+module.exports = { ReplyPattern, GuildMessageHandler, ClientMessageHandler };

--- a/internal/messages.js
+++ b/internal/messages.js
@@ -125,8 +125,8 @@ class ReplyPattern {
 
     toString() {
         return strFormat(LANG.internal.messages.replyPattern, {
-            message: this.message,
-            reply: this.reply,
+            message: '`' + this.message + '`',
+            reply: '`' + this.reply + '`',
             perfectMatching: this.perfectMatching
                 ? LANG.internal.messages.perfectMatching.yes
                 : LANG.internal.messages.perfectMatching.no

--- a/internal/messages.js
+++ b/internal/messages.js
@@ -36,7 +36,6 @@ const { Collection } = require("mongoose");
  * @property {string} message 反応するメッセージ内容
  * @property {string} reply 返信内容
  * @property {boolean} perfectMatching 完全一致する必要があるか
- * @property {boolean} regularExpression 正規表現を用いるか
  */
 
 /** @type {Collection<ReplyGuildSchema>} */
@@ -110,7 +109,6 @@ class ReplyPattern {
             message: message,
             reply: this.reply,
             perfectMatching: this.perfectMatching,
-            regularExpression: false
         };
     }
 

--- a/internal/messages.js
+++ b/internal/messages.js
@@ -22,6 +22,16 @@ const axios = require('axios').default;
 const { strFormat, LANG } = require("../util/languages");
 
 /**
+ * @typedef {Object} ReplySchema replies コレクションのドキュメント。
+ * @property {string} client
+ * @property {string} guild
+ * @property {string} message
+ * @property {string} reply
+ * @property {boolean} perfectMatching
+ * @property {boolean} regularExpression
+ */
+
+/**
  * 自動応答のパターン。
  */
 class ReplyPattern {
@@ -70,6 +80,24 @@ class ReplyPattern {
             }
         }
         return null;
+    }
+
+    /**
+     * replies コレクションに格納できる形式に変換する。
+     * @param {string} clientUserId クライアントのユーザー ID
+     * @param {string} guildId サーバー ID
+     * @returns {ReplySchema}
+     */
+    serialize(clientUserId, guildId) {
+        const messagePattern = this.messagePattern;
+        return {
+            client: clientUserId,
+            guild: guildId,
+            message: messagePattern,
+            reply: this.reply,
+            perfectMatching: this.perfectMatching,
+            regularExpression: false
+        };
     }
 }
 

--- a/internal/messages.js
+++ b/internal/messages.js
@@ -53,7 +53,7 @@ class ReplyPattern {
      * @readonly
      * @type {string}
      */
-    messagePattern;
+    message;
 
     /**
      * @readonly
@@ -73,7 +73,7 @@ class ReplyPattern {
      * @param {boolean=} perfectMatching 完全一致する必要があるか
      */
     constructor(messagePattern, reply, perfectMatching = false) {
-        this.messagePattern = messagePattern;
+        this.message = messagePattern;
         this.reply = reply;
         this.perfectMatching = perfectMatching;
     }
@@ -85,11 +85,11 @@ class ReplyPattern {
      */
     apply(message) {
         if (this.perfectMatching) {
-            if (message == this.messagePattern) {
+            if (message == this.message) {
                 return this.reply;
             }
         } else {
-            if (message.includes(this.messagePattern)) {
+            if (message.includes(this.message)) {
                 return this.reply;
             }
         }
@@ -103,11 +103,11 @@ class ReplyPattern {
      * @returns {ReplySchema}
      */
     serialize(clientUserId, guildId) {
-        const messagePattern = this.messagePattern;
+        const message = this.message;
         return {
             client: clientUserId,
             guild: guildId,
-            message: messagePattern,
+            message: message,
             reply: this.reply,
             perfectMatching: this.perfectMatching,
             regularExpression: false
@@ -125,7 +125,7 @@ class ReplyPattern {
 
     toString() {
         return strFormat(LANG.internal.messages.replyPattern, {
-            message: this.messagePattern,
+            message: this.message,
             reply: this.reply,
             perfectMatching: this.perfectMatching
                 ? LANG.internal.messages.perfectMatching.yes
@@ -189,11 +189,11 @@ class GuildMessageHandler {
      */
     async addReplyPattern(replyPattern) {
         const replyPatterns = await this.replyPatternsPromise;
-        const addingMessagePattern = replyPattern.messagePattern;
-        if (replyPatterns.has(addingMessagePattern)) {
+        const message = replyPattern.message;
+        if (replyPatterns.has(message)) {
             return false;
         }
-        replyPatterns.set(replyPattern.messagePattern, replyPattern);
+        replyPatterns.set(replyPattern.message, replyPattern);
         await replyCollection.insertOne(
             replyPattern.serialize(this.client.user.id, this.guildId)
         );
@@ -297,7 +297,7 @@ async function loadReplies(clientUserId, guildId) {
     });
     for await (const replyDocument of replyDocuments) {
         const replyPattern = ReplyPattern.deserialize(replyDocument);
-        result.set(replyPattern.messagePattern, replyPattern);
+        result.set(replyPattern.message, replyPattern);
     }
     return result;
 }

--- a/internal/messages.js
+++ b/internal/messages.js
@@ -197,6 +197,26 @@ class GuildMessageHandler {
         );
         return true;
     }
+
+    /**
+     * 自動応答のパターンを削除する。
+     * @param {string} message 反応するメッセージ内容
+     * @returns 削除した ReplyPattern または、存在しなかった場合 null
+     */
+    async removeReplyPattern(message) {
+        const replyPatterns = await this.replyPatternsPromise;
+        const replyPattern = replyPatterns.get(message);
+        if (replyPattern == null) {
+            return null;
+        }
+        replyPatterns.delete(message);
+        await replyCollection.deleteOne({
+            client: this.client.user.id,
+            guild: this.guildId,
+            message,
+        });
+        return replyPattern;
+    }
 }
 
 /**

--- a/internal/messages.js
+++ b/internal/messages.js
@@ -38,11 +38,20 @@ const { Collection } = require("mongoose");
  * @property {boolean} perfectMatching 完全一致する必要があるか
  */
 
-/** @type {Collection<ReplyGuildSchema>} */
-const replyGuildCollection = mongodb.connection.collection('replyGuilds');
+/**
+ * @return {Collection<ReplyGuildSchema>}
+ */
+function getReplyGuildCollection() {
+    return mongodb.connection.collection('replyGuilds');
+}
 
-/** @type {Collection<ReplySchema>} */
-const replyCollection = mongodb.connection.collection('replies');
+/**
+ * @return {Collection<ReplySchema>}
+ */
+function getReplyCollection() {
+    return mongodb.connection.collection('replies');
+}
+
 
 /**
  * 自動応答のパターン。
@@ -192,7 +201,7 @@ class GuildMessageHandler {
             return false;
         }
         replyPatterns.set(replyPattern.message, replyPattern);
-        await replyCollection.insertOne(
+        await getReplyCollection().insertOne(
             replyPattern.serialize(this.client.user.id, this.guildId)
         );
         return true;
@@ -210,7 +219,7 @@ class GuildMessageHandler {
             return null;
         }
         replyPatterns.delete(message);
-        await replyCollection.deleteOne({
+        await getReplyCollection().deleteOne({
             client: this.client.user.id,
             guild: this.guildId,
             message,
@@ -303,6 +312,8 @@ const defaultReplyPatterns = [new ReplyPattern('それはそう', 'https://soreh
  * @param {string} guildId サーバー ID
  */
 async function loadReplies(clientUserId, guildId) {
+    const replyGuildCollection = getReplyGuildCollection();
+    const replyCollection = getReplyCollection();
     const replyGuildDocument = await replyGuildCollection.findOne({
         client: clientUserId,
         guild: guildId

--- a/internal/messages.js
+++ b/internal/messages.js
@@ -217,6 +217,15 @@ class GuildMessageHandler {
         });
         return replyPattern;
     }
+
+    /**
+     * 自動応答のパターンを全て取得する。
+     * @returns {Promise<ReplyPattern[]>} {@link ReplyPattern} の配列
+     */
+    async getReplyPatterns() {
+        const replyPatterns = await this.replyPatternsPromise;
+        return [...replyPatterns.values()];
+    }
 }
 
 /**

--- a/internal/messages.test.js
+++ b/internal/messages.test.js
@@ -1,0 +1,15 @@
+// @ts-check
+
+const { ReplyPattern } = require("./messages");
+
+test('ReplyPattern.match', () => {
+    const pattern1 = new ReplyPattern('それはそう', 'https://soreha.so/');
+    const pattern2 = new ReplyPattern('それはそう', 'https://soreha.so/', true);
+
+    expect(pattern1.apply('それはそう')).toBe('https://soreha.so/');
+    expect(pattern1.apply('それ')).toBe(null);
+    expect(pattern1.apply('それはそう。')).toBe('https://soreha.so/');
+    expect(pattern2.apply('それはそう')).toBe('https://soreha.so/');
+    expect(pattern2.apply('それ')).toBe(null);
+    expect(pattern2.apply('それはそう。')).toBe(null);
+});

--- a/language/default.json
+++ b/language/default.json
@@ -537,9 +537,13 @@
                     "name": "remove",
                     "description": "自動応答を削除します。",
                     "options": {
-                        "name": "message",
-                        "description": "反応するメッセージ内容"
-                    }
+                        "message": {
+                            "name": "message",
+                            "description": "反応するメッセージ内容"
+                        }
+                    },
+                    "succeeded": "メッセージに対する応答を削除しました！",
+                    "doNotExist": "そのメッセージに対する応答は設定されていません！"
                 },
                 "list": {
                     "name": "list",

--- a/language/default.json
+++ b/language/default.json
@@ -528,10 +528,6 @@
                         "perfectMatching": {
                             "name": "perfect_matching",
                             "description": "完全一致"
-                        },
-                        "regularExpression": {
-                            "name": "regexp",
-                            "description": "正規表現を用いる"
                         }
                     },
                     "succeeded": "メッセージに対する応答を設定しました！",

--- a/language/default.json
+++ b/language/default.json
@@ -502,6 +502,46 @@
                 "footer": "実行者: ${0}"
             }
         },
+        "reply": {
+            "name": "reply",
+            "description": "自動応答をカスタマイズします。",
+            "subcommands": {
+                "add": {
+                    "name": "add",
+                    "description": "自動応答を追加します。",
+                    "options": {
+                        "message": {
+                            "name": "message",
+                            "description": "反応するメッセージ内容"
+                        },
+                        "reply": {
+                            "name": "reply",
+                            "description": "返信内容"
+                        },
+                        "perfectMatching": {
+                            "name": "perfect_matching",
+                            "description": "完全一致"
+                        },
+                        "regularExpression": {
+                            "name": "regexp",
+                            "description": "正規表現を用いる"
+                        }
+                    }
+                },
+                "remove": {
+                    "name": "remove",
+                    "description": "自動応答を削除します。",
+                    "options": {
+                        "name": "message",
+                        "description": "反応するメッセージ内容"
+                    }
+                },
+                "list": {
+                    "name": "list",
+                    "description": "自動応答の一覧を表示します。"
+                }
+            }
+        },
         "resume": {
             "name": "resume",
             "description": "音楽の再生を再開します",

--- a/language/default.json
+++ b/language/default.json
@@ -63,6 +63,13 @@
             "presenceNameShuttingDown": "Shutting down...",
             "presenceStateShuttingDown": "Sekai.explode is now shutting down..."
         },
+        "messages": {
+            "replyPattern": "${message} -> ${reply}${perfectMatching}",
+            "perfectMatching": {
+                "yes": " (完全一致)",
+                "no": ""
+            }
+        },
         "mongodb": {
             "called": "Called mongodb internal system.",
             "dbConnecting": "[MongoDB] Connecting...",
@@ -526,7 +533,9 @@
                             "name": "regexp",
                             "description": "正規表現を用いる"
                         }
-                    }
+                    },
+                    "succeeded": "メッセージに対する応答を設定しました！",
+                    "alreadyExists": "そのメッセージに対する応答はすでに設定されています！"
                 },
                 "remove": {
                     "name": "remove",
@@ -540,7 +549,8 @@
                     "name": "list",
                     "description": "自動応答の一覧を表示します。"
                 }
-            }
+            },
+            "notInGuildError": "このコマンドはサーバー内でのみ使用できます！"
         },
         "resume": {
             "name": "resume",

--- a/language/default.json
+++ b/language/default.json
@@ -64,7 +64,7 @@
             "presenceStateShuttingDown": "Sekai.explode is now shutting down..."
         },
         "messages": {
-            "replyPattern": "${message} -> ${reply}${perfectMatching}",
+            "replyPattern": "${message}: ${reply}${perfectMatching}",
             "perfectMatching": {
                 "yes": " (完全一致)",
                 "no": ""

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "ytdl-core": "^4.11.5"
       },
       "devDependencies": {
+        "@types/jest": "^29.5.12",
         "jest": "^29.7.0"
       }
     },
@@ -1421,6 +1422,16 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "author": "ringo360",
   "license": "GPL-3.0-only",
   "devDependencies": {
+    "@types/jest": "^29.5.12",
     "jest": "^29.7.0"
   },
   "scripts": {

--- a/util/types.js
+++ b/util/types.js
@@ -2,10 +2,10 @@
 
 // 汎用的な型を定義するファイル
 
-const { CommandInteraction } = require("discord.js");
+const { ChatInputCommandInteraction } = require("discord.js");
 
 /**
  * @typedef {Object} Command スラッシュコマンドを表すオブジェクト
  * @property {import("discord.js").SlashCommandSubcommandsOnlyBuilder} data Discord の API に登録するデータ
- * @property {(interaction: CommandInteraction) => Promise<void>} execute コマンドの処理
+ * @property {(interaction: ChatInputCommandInteraction) => Promise<void>} execute コマンドの処理
  */

--- a/util/types.js
+++ b/util/types.js
@@ -2,10 +2,10 @@
 
 // 汎用的な型を定義するファイル
 
-const { SlashCommandBuilder, CommandInteraction } = require("discord.js");
+const { CommandInteraction } = require("discord.js");
 
 /**
  * @typedef {Object} Command スラッシュコマンドを表すオブジェクト
- * @property {SlashCommandBuilder} data Discord の API に登録するデータ
+ * @property {import("discord.js").SlashCommandSubcommandsOnlyBuilder} data Discord の API に登録するデータ
  * @property {(interaction: CommandInteraction) => Promise<void>} execute コマンドの処理
  */


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
コマンド `/reply` を追加しました。
`/reply add` で自動応答の追加、`/reply remove` で削除、`/reply list` で確認ができます。
自動応答はサーバーごとに設定でき、デフォルトで「それはそう」→「https\://soraha.so/」のパターンが設定されます。

## 変更点
- `internal/messages.js` にクラス `ClientMessageHandler`, `GuildMessageHandler`, `ReplyPattern` を定義
- `discordbot.js` にあった `'messageCreate'` イベントのハンドラを `ClientMessageHandler#handleMessage` メソッドに移動
- `internal/message.js` に定義されたクラスのインスタンスを操作する `/reply` コマンドの追加

<!--- 変更点の記述 -->

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
