### PR TITLE
自動応答のカスタマイズに権限確認の追加

### DIFF
--- a/commands/reply.js
+++ b/commands/reply.js
@@ -81,7 +81,7 @@ const commandReply = {
             }
 
             case LANG.commands.reply.subcommands.remove.name: {
-                if (!checkPermission(interaction)) {
+                if (!await checkPermission(interaction)) {
                     return;
                 }
                 const replyPattern = await guildMessageHandler.removeReplyPattern(

--- a/commands/reply.js
+++ b/commands/reply.js
@@ -1,10 +1,11 @@
 // @ts-check
 
 const assert = require('assert');
-const { SlashCommandBuilder } = require("discord.js");
+const { SlashCommandBuilder, ChatInputCommandInteraction } = require("discord.js");
 const { LANG } = require("../util/languages");
 const { ClientMessageHandler, ReplyPattern } = require("../internal/messages");
 const Pager = require('../util/pager');
+const config = require("../config.json");
 
 /** @type {import("../util/types").Command} */
 const commandReply = {
@@ -59,6 +60,9 @@ const commandReply = {
 
         switch (subcommand) {
             case LANG.commands.reply.subcommands.add.name: {
+                if (!await checkPermission(interaction)) {
+                    return;
+                }
                 const replyPattern = new ReplyPattern(
                     interaction.options.getString(LANG.commands.reply.subcommands.add.options.message.name, true),
                     interaction.options.getString(LANG.commands.reply.subcommands.add.options.reply.name, true),
@@ -77,6 +81,9 @@ const commandReply = {
             }
 
             case LANG.commands.reply.subcommands.remove.name: {
+                if (!checkPermission(interaction)) {
+                    return;
+                }
                 const replyPattern = await guildMessageHandler.removeReplyPattern(
                     interaction.options.getString(LANG.commands.reply.subcommands.remove.options.message.name, true)
                 );
@@ -107,5 +114,20 @@ const commandReply = {
         }
     }
 };
+
+/**
+ * 使う権限があるかをチェックする。
+ * @param {ChatInputCommandInteraction} interaction
+ */
+async function checkPermission(interaction) {
+    if (!config.replyEditionAllowedUsers?.includes(interaction.user.id)) {
+        await interaction.reply({
+            content: LANG.commands.reply.permissionError,
+            ephemeral: true,
+        });
+        return false;
+    }
+    return true;
+}
 
 module.exports = commandReply;

--- a/commands/reply.js
+++ b/commands/reply.js
@@ -120,7 +120,7 @@ const commandReply = {
  * @param {ChatInputCommandInteraction} interaction
  */
 async function checkPermission(interaction) {
-    if (!config.replyEditionAllowedUsers?.includes(interaction.user.id)) {
+    if (!config.replyCustomizeAllowedUsers?.includes(interaction.user.id)) {
         await interaction.reply({
             content: LANG.commands.reply.permissionError,
             ephemeral: true,

--- a/config.json.example
+++ b/config.json.example
@@ -15,7 +15,7 @@
 	"cfPurgeUrl": "https://cdn.yourdomain.com/",
 	"AdminRoleID": "00000000000",
 	"AdminUserIDs": ["1063527758292070591", "1126422758696427552"],
-	"replyEditionAllowedUsers": ["00000000000","16326412825651210244096"],
+	"replyCustomizeAllowedUsers": ["00000000000","16326412825651210244096"],
 	"mongoDBhost": "127.0.0.1",
 	"mongoDBport": "27017",
 	"mongoDBuser": "admin",

--- a/config.json.example
+++ b/config.json.example
@@ -15,6 +15,7 @@
 	"cfPurgeUrl": "https://cdn.yourdomain.com/",
 	"AdminRoleID": "00000000000",
 	"AdminUserIDs": ["1063527758292070591", "1126422758696427552"],
+	"replyEditionAllowedUsers": ["00000000000","16326412825651210244096"],
 	"mongoDBhost": "127.0.0.1",
 	"mongoDBport": "27017",
 	"mongoDBuser": "admin",

--- a/language/default.json
+++ b/language/default.json
@@ -550,7 +550,8 @@
                     "description": "自動応答の一覧を表示します。"
                 }
             },
-            "notInGuildError": "このコマンドはサーバー内でのみ使用できます！"
+            "notInGuildError": "このコマンドはサーバー内でのみ使用できます！",
+            "permissionError": "このコマンドを使用する権限がありません！"
         },
         "resume": {
             "name": "resume",


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
configの`replyCustomizeAllowedUsers`に/reply addと/reply removeの使用を許可するユーザーを指定できるようにしました。

## 変更点

<!--- 変更点の記述 -->
- `config.json` に `replyCustomizeAllowedUsers` を追加し、/replyコマンドで実行者のユーザーのidがその配列に含まれているかを確認

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
