### PR TITLE
discordbot.jsでMongoDBに接続 (#60)

### DIFF
--- a/discordbot.js
+++ b/discordbot.js
@@ -14,6 +14,8 @@ const { onShutdown } = require('./internal/schedules');
 const activity = require('./internal/activity');
 const mongodb = require('./internal/mongodb');
 
+mongodb.connectMongoose();
+
 const {
 	getDuration,
 	saveQueue,

--- a/internal/mongodb.js
+++ b/internal/mongodb.js
@@ -2,10 +2,8 @@ const mongoose = require('mongoose');
 const config = require('../config.json');
 const { LANG } = require('../util/languages');
 
-console.log(LANG.internal.mongodb.called);
-connectMongoose();
-
 async function connectMongoose() {
+	console.log(LANG.internal.mongodb.called);
 	try {
 		await mongoose.connect(
 			`mongodb://${config.mongoDBuser}:${config.mongoDBpass}@${config.mongoDBhost}:${config.mongoDBport}/${config.mongoDBdatabase}?authSource=admin`,
@@ -30,6 +28,7 @@ db.on('disconnected', function () {
 });
 
 module.exports = {
+	connectMongoose,
 	connection: db,
 	mongoose: mongoose,
 };


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
`discordbot.js` で MongoDB に接続するようにして、Jest によるテスト時には接続しないようにしました。

## 変更点

<!--- 変更点の記述 -->
- `internal/mongodb.js` が呼び出された旨をログに出すコードを `connectMongoose` 関数内に移動
- `internal/mongodb.js` の `connectMongoose` 関数をエクスポート
- `connectMongoose` の呼び出しを `discordbot.js` に移動

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
