### PR TITLE
/dmでmodalを使用するようにする + workflowの調整

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -2,7 +2,9 @@ name: Code Test and Deploy
 
 on:
   push:
-    branches: v14-dev
+    branches:
+        - '**'
+        - '!v14-stable'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/packages/misc/commands/dm.js
+++ b/packages/misc/commands/dm.js
@@ -51,6 +51,12 @@ module.exports = {
 		const userId = interaction.options.getUser(
 			LANG.commands.dm.options.user.name,
 		);
+		if (userId === interaction.user.bot) {
+			await interaction.reply({
+				content: 'Botに対して実行することはできません!',
+				ephemeral: true,
+			});
+		}
 
 		const modal = new ModalBuilder()
 			.setCustomId('modaldm')

--- a/packages/misc/commands/dm.js
+++ b/packages/misc/commands/dm.js
@@ -80,6 +80,13 @@ module.exports = {
 			.catch((e) => console.error(e));
 		if (submitted) {
 			const msg = submitted.fields.getTextInputValue('content');
+			const msglength = msg.length;
+			if (msg > 1024) {
+				return await interaction.reply({
+					content: '文字の長さは1024文字以下にしてください!',
+					ephemeral: true,
+				});
+			}
 			const userName = userId.username;
 			await submitted.reply(strFormat(LANG.commands.dm.dmSent, [userName]));
 			const dmChannel = await userId.createDM();

--- a/packages/misc/commands/dm.js
+++ b/packages/misc/commands/dm.js
@@ -41,18 +41,11 @@ module.exports = {
 			}
 		}
 
-		/* TODO 実装? コメントアウトを削除?
-		let isSilent = false;
-		if (interaction.options.getBoolean("silent")) {
-			isSilent = interaction.options.getBoolean("silent");
-		}
-		*/
-
 		const userId = interaction.options.getUser(
 			LANG.commands.dm.options.user.name,
 		);
-		if (userId === interaction.user.bot) {
-			await interaction.reply({
+		if (userId.bot) {
+			return await interaction.reply({
 				content: 'Botに対して実行することはできません!',
 				ephemeral: true,
 			});
@@ -73,40 +66,44 @@ module.exports = {
 		modal.addComponents(firstRow);
 		await interaction.showModal(modal);
 		// const filter = (mInteraction) => mInteraction.customId === 'gbanreport';
-		const submitted = await interaction
-			.awaitModalSubmit({
-				time: 60000,
-				filter: (i) => i.user.id === interaction.user.id,
-			})
-			.catch((e) => console.error(e));
-		if (submitted) {
-			const msg = submitted.fields.getTextInputValue('content');
-			const userName = userId.username;
-			await submitted.reply(strFormat(LANG.commands.dm.dmSent, [userName]));
-			const dmChannel = await userId.createDM();
+		try {
+			const submitted = await interaction
+				.awaitModalSubmit({
+					time: 60000,
+					filter: (i) => i.user.id === interaction.user.id,
+				})
+				.catch((e) => console.error(e));
+			if (submitted) {
+				const msg = submitted.fields.getTextInputValue('content');
+				const userName = userId.username;
+				await submitted.reply(strFormat(LANG.commands.dm.dmSent, [userName]));
+				const dmChannel = await userId.createDM();
 
-			dmChannel.send({
-				embeds: [
-					{
-						title: strFormat(LANG.commands.dm.messageTitle, [
-							interaction.user.username,
-						]),
-						thumbnail: {
-							url: interaction.user.displayAvatarURL(),
-						},
-						color: 0x5865f2,
-						fields: [
-							{
-								name: LANG.commands.dm.messageFieldName,
-								value: msg,
+				dmChannel.send({
+					embeds: [
+						{
+							title: strFormat(LANG.commands.dm.messageTitle, [
+								interaction.user.username,
+							]),
+							thumbnail: {
+								url: interaction.user.displayAvatarURL(),
 							},
-						],
-					},
-				],
-			});
+							color: 0x5865f2,
+							fields: [
+								{
+									name: LANG.commands.dm.messageFieldName,
+									value: msg,
+								},
+							],
+						},
+					],
+				});
+			}
+		} catch (e) {
+			console.error(e);
+		} finally {
+			const expirationTime = Date.now() + cooldownTime * 1000;
+			cooldowns.set(executorId, expirationTime);
 		}
-
-		const expirationTime = Date.now() + cooldownTime * 1000;
-		cooldowns.set(executorId, expirationTime);
 	},
 };

--- a/packages/misc/commands/dm.js
+++ b/packages/misc/commands/dm.js
@@ -75,7 +75,6 @@ module.exports = {
 		if (submitted) {
 			const msg = submitted.fields.getTextInputValue('content');
 			const userName = userId.username;
-			await interaction.reply();
 			await submitted.reply(strFormat(LANG.commands.dm.dmSent, [userName]));
 			const dmChannel = await userId.createDM();
 

--- a/packages/misc/commands/dm.js
+++ b/packages/misc/commands/dm.js
@@ -67,7 +67,8 @@ module.exports = {
 			.setLabel('送信したいメッセージ')
 			.setStyle(TextInputStyle.Paragraph)
 			.setPlaceholder('送りたいメッセージをここに記入...')
-			.setRequired(true);
+			.setRequired(true)
+			.setMaxLength(1024);
 		const firstRow = new ActionRowBuilder().addComponents(msgcontent);
 		modal.addComponents(firstRow);
 		await interaction.showModal(modal);
@@ -80,13 +81,6 @@ module.exports = {
 			.catch((e) => console.error(e));
 		if (submitted) {
 			const msg = submitted.fields.getTextInputValue('content');
-			const msglength = msg.length;
-			if (msg > 1024) {
-				return await interaction.reply({
-					content: '文字の長さは1024文字以下にしてください!',
-					ephemeral: true,
-				});
-			}
 			const userName = userId.username;
 			await submitted.reply(strFormat(LANG.commands.dm.dmSent, [userName]));
 			const dmChannel = await userId.createDM();

--- a/packages/misc/commands/dm.js
+++ b/packages/misc/commands/dm.js
@@ -17,12 +17,6 @@ module.exports = {
 				.setName(LANG.commands.dm.options.user.name)
 				.setDescription(LANG.commands.dm.options.user.description)
 				.setRequired(true),
-		)
-		.addStringOption((option) =>
-			option
-				.setName(LANG.commands.dm.options.text.name)
-				.setDescription(LANG.commands.dm.options.text.description)
-				.setRequired(true),
 		),
 	/* .addBooleanOption(option =>
 			option
@@ -79,7 +73,7 @@ module.exports = {
 			})
 			.catch((e) => console.error(e));
 		if (submitted) {
-			const msg = submitted.fields.getTextInputValue('msg');
+			const msg = submitted.fields.getTextInputValue('content');
 			const userName = userId.username;
 			await interaction.reply();
 			await submitted.reply(strFormat(LANG.commands.dm.dmSent, [userName]));

--- a/packages/misc/commands/dm.js
+++ b/packages/misc/commands/dm.js
@@ -1,4 +1,10 @@
-const { SlashCommandBuilder } = require('discord.js');
+const {
+	SlashCommandBuilder,
+	ModalBuilder,
+	TextInputBuilder,
+	TextInputStyle,
+	ActionRowBuilder,
+} = require('discord.js');
 const { LANG, strFormat } = require('../../../util/languages');
 const cooldowns = new Map();
 


### PR DESCRIPTION
## 内容

✨このPRにより、 #68 をクローズすることができます。

`/dm`で送信した内容が第三者に見られてしまう事を防ぐために、Modalを使用して送信するようにしました。

これにより、第三者がDMの内容を閲覧できなくなる上に、ユーザーがより内容を入力しやすくなります。

また、このPRにはWorkflow関連の調整が含まれています。

## 変更点
* Workflow内にある`test-and-deploy.yml`の対象となるブランチを調整しました。
```diff
- branches: v14-dev

+ branches:
+  - '**'
+  - '!v14-stable'
```

* `/dm`のメッセージをModalで送信するようにしました。


## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
