### PR TITLE
/gban reportに秒数制限をかける

### DIFF
--- a/packages/admin/commands/globalban.js
+++ b/packages/admin/commands/globalban.js
@@ -370,7 +370,7 @@ module.exports = {
 				});
 			}
 		} else if (subcommand === 'report') {
-			const cooldownTime = 10;
+			const cooldownTime = 30;
 			if (cooldowns.has(interaction.user.id)) {
 				const expirationTime = cooldowns.get(interaction.user.id);
 				const currTime = Date.now();

--- a/packages/admin/commands/globalban.js
+++ b/packages/admin/commands/globalban.js
@@ -82,7 +82,7 @@ module.exports = {
 		}
 
 		if (subcommand !== 'report') {
-			console.log('Defering');
+			// console.log('Defering'); devlog
 			await interaction.deferReply();
 		}
 		if (subcommand === LANG.commands.globalban.subcommands.sync.name) {
@@ -430,7 +430,7 @@ module.exports = {
 				const d = new Date();
 				const u = d.getTime();
 				const fxunix = Math.floor(u / 1000);
-				return await channel.send({
+				await channel.send({
 					embeds: [
 						{
 							title: `レポートが届きました!`,

--- a/packages/admin/commands/globalban.js
+++ b/packages/admin/commands/globalban.js
@@ -451,7 +451,7 @@ module.exports = {
 				});
 			}
 			const expirationTime = Date.now() + cooldownTime * 1000;
-			cooldowns.set(executorId, expirationTime);
+			cooldowns.set(interaction.user.id, expirationTime);
 			return;
 		} else {
 			return await interaction.editReply(


### PR DESCRIPTION
## 内容
このPRは #71 をクローズします。

* `/gban report`に30秒のクールダウンを設け、ユーザーからのスパムを防止します。

## 変更点

* `globalban.js`のレポート処理部分に`dm.js`と同様の仕組みでクールダウンを追加

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
