### PR TITLE
Feature/54 command cal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Font file
+*.ttf

--- a/config.json.example
+++ b/config.json.example
@@ -26,5 +26,7 @@
 	"rconpass1": "yourpassword1234",
 	"syslogChannel": "1151139585791901746",
 	"notificationChannel": "1151139585791901746",
-	"language": "default"
+	"language": "default",
+	"fontFile": "font.ttf",
+	"fontFamily": "sans-serif"
 }

--- a/language/default.json
+++ b/language/default.json
@@ -117,6 +117,11 @@
 		}
 	},
 	"commands": {
+		"cal": {
+			"name": "cal",
+			"description": "カレンダーを表示します",
+			"dayLabels": ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+		},
 		"check": {
 			"name": "check",
 			"description": "Ping Checker",

--- a/language/default.json
+++ b/language/default.json
@@ -120,7 +120,22 @@
 		"cal": {
 			"name": "cal",
 			"description": "カレンダーを表示します",
-			"dayLabels": ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+			"dayLabels": ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+			"monthNames": [
+				"1月",
+				"2月",
+				"3月",
+				"4月",
+				"5月",
+				"6月",
+				"7月",
+				"8月",
+				"9月",
+				"10月",
+				"11月",
+				"12月"
+			],
+			"monthYear": "${year}年${month}"
 		},
 		"check": {
 			"name": "check",

--- a/language/default.json
+++ b/language/default.json
@@ -120,6 +120,29 @@
 		"cal": {
 			"name": "cal",
 			"description": "カレンダーを表示します",
+			"options": {
+				"month": {
+					"name": "month",
+					"description": "月"
+				},
+				"year": {
+					"name": "year",
+					"description": "年"
+				},
+				"weekStart": {
+					"name": "week_start",
+					"description": "週の始まりの曜日"
+				}
+			},
+			"dayNames": [
+				"日曜日",
+				"月曜日",
+				"火曜日",
+				"水曜日",
+				"木曜日",
+				"金曜日",
+				"土曜日"
+			],
 			"dayLabels": ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
 			"monthNames": [
 				"1月",

--- a/language/en.json
+++ b/language/en.json
@@ -117,6 +117,49 @@
 		}
 	},
 	"commands": {
+		"cal": {
+			"name": "cal",
+			"description": "Shows the calendar",
+			"options": {
+				"month": {
+					"name": "month",
+					"description": "Month"
+				},
+				"year": {
+					"name": "year",
+					"description": "Year"
+				},
+				"weekStart": {
+					"name": "week_start",
+					"description": "The days to start weeks"
+				}
+			},
+			"dayNames": [
+				"Sunday",
+				"Monday",
+				"Tuesday",
+				"Wednesday",
+				"Thursday",
+				"Friday",
+				"Saturday"
+			],
+			"dayLabels": ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+			"monthNames": [
+				"January",
+				"February",
+				"March",
+				"April",
+				"May",
+				"June",
+				"July",
+				"August",
+				"September",
+				"October",
+				"November",
+				"December"
+			],
+			"monthYear": "${month} ${year}"
+		},
 		"check": {
 			"name": "check",
 			"description": "Ping Checker",

--- a/language/ja.json
+++ b/language/ja.json
@@ -117,6 +117,49 @@
 		}
 	},
 	"commands": {
+		"cal": {
+			"name": "cal",
+			"description": "カレンダーを表示します",
+			"options": {
+				"month": {
+					"name": "month",
+					"description": "月"
+				},
+				"year": {
+					"name": "year",
+					"description": "年"
+				},
+				"weekStart": {
+					"name": "week_start",
+					"description": "週の始まりの曜日"
+				}
+			},
+			"dayNames": [
+				"日曜日",
+				"月曜日",
+				"火曜日",
+				"水曜日",
+				"木曜日",
+				"金曜日",
+				"土曜日"
+			],
+			"dayLabels": ["日", "月", "火", "水", "木", "金", "土"],
+			"monthNames": [
+				"1月",
+				"2月",
+				"3月",
+				"4月",
+				"5月",
+				"6月",
+				"7月",
+				"8月",
+				"9月",
+				"10月",
+				"11月",
+				"12月"
+			],
+			"monthYear": "${year}年${month}"
+		},
 		"check": {
 			"name": "check",
 			"description": "Ping を確認",

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -1,6 +1,6 @@
 import { createCanvas } from 'canvas';
 import { SimpleSlashCommandBuilder } from '../../../common/SimpleCommand';
-import { LANG } from '../../../util/languages';
+import { LANG, strFormat } from '../../../util/languages';
 import { DayOfWeek, MonthCalendar } from '../util/calendar';
 import { BoundingBox, CanvasTable, InlineText } from '../util/canvasUtils';
 
@@ -50,7 +50,10 @@ export default SimpleSlashCommandBuilder.create(
 		],
 		embeds: [
 			{
-				title: 'カレンダー',
+				title: strFormat(LANG.commands.cal.monthYear, {
+					month: LANG.commands.cal.monthNames[calendar.month],
+					year: calendar.year,
+				}),
 				image: {
 					url: 'attachment://calendar.png',
 				},

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -1,9 +1,10 @@
 import { SimpleSlashCommandBuilder } from '../../../common/SimpleCommand';
+import { LANG } from '../../../util/languages';
 import { MonthCalendar } from '../util/calendar';
 
 export default SimpleSlashCommandBuilder.create(
-	'cal',
-	'カレンダーを表示します',
+	LANG.commands.cal.name,
+	LANG.commands.cal.description,
 ).build(async (interaction) => {
 	const calendar = new MonthCalendar();
 	const days = Array.from(calendar.weeks())
@@ -15,5 +16,7 @@ export default SimpleSlashCommandBuilder.create(
 				.join(' '),
 		)
 		.join('\n');
-	await interaction.reply('```Su Mo Tu We Th Fr Sa\n' + days + '```');
+	await interaction.reply(
+		'```' + LANG.commands.cal.dayLabels.join(' ') + '\n' + days + '```',
+	);
 });

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -25,6 +25,7 @@ export default SimpleSlashCommandBuilder.create(
 	LANG.commands.cal.description,
 ).build(async (interaction) => {
 	const calendar = new MonthCalendar();
+	const today = new Date();
 	const table = [
 		LANG.commands.cal.dayLabels.map((e, i) => {
 			const text = new InlineText(e);
@@ -35,6 +36,12 @@ export default SimpleSlashCommandBuilder.create(
 			week.map((day) => {
 				const text = new InlineText(day.date.toString());
 				text.color = dayColor(day.day);
+				if (!calendar.includes(day)) {
+					text.color = 'gray';
+				}
+				if (day.is(today)) {
+					text.font = 'bold 24px serif';
+				}
 				return text;
 			}),
 		),

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -2,7 +2,12 @@ import { createCanvas } from 'canvas';
 import { SimpleSlashCommandBuilder } from '../../../common/SimpleCommand';
 import { LANG, strFormat } from '../../../util/languages';
 import { DayOfWeek, MonthCalendar } from '../util/calendar';
-import { BoundingBox, CanvasTable, InlineText } from '../util/canvasUtils';
+import {
+	BoundingBox,
+	CanvasTable,
+	CanvasTextBox,
+	InlineText,
+} from '../util/canvasUtils';
 
 function dayColor(day: DayOfWeek) {
 	switch (day) {
@@ -37,9 +42,15 @@ export default SimpleSlashCommandBuilder.create(
 	const canvas = createCanvas(800, 400);
 	const ctx = canvas.getContext('2d');
 	new BoundingBox(0, 0, 800, 400).fill(ctx, 'white');
-	const canvasTable = new CanvasTable(table, new BoundingBox(50, 50, 700, 300));
-	canvasTable.color = 'black';
-	canvasTable.renderTo(ctx);
+	const title = strFormat(LANG.commands.cal.monthYear, {
+		month: LANG.commands.cal.monthNames[calendar.month],
+		year: calendar.year,
+	});
+	const titleStyle = new InlineText(title);
+	titleStyle.color = 'black';
+	titleStyle.font = '48px serif';
+	new CanvasTextBox(titleStyle, new BoundingBox(50, 0, 700, 100)).renderTo(ctx);
+	new CanvasTable(table, new BoundingBox(50, 100, 700, 300)).renderTo(ctx);
 	await interaction.reply({
 		files: [
 			{
@@ -49,10 +60,7 @@ export default SimpleSlashCommandBuilder.create(
 		],
 		embeds: [
 			{
-				title: strFormat(LANG.commands.cal.monthYear, {
-					month: LANG.commands.cal.monthNames[calendar.month],
-					year: calendar.year,
-				}),
+				title: strFormat(title),
 				image: {
 					url: 'attachment://calendar.png',
 				},

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -28,7 +28,7 @@ export default SimpleSlashCommandBuilder.create(
 		}),
 		...Array.from(calendar.weeks()).map((week) =>
 			week.map((day) => {
-				const text = new InlineText(day.date.toString().padStart(2));
+				const text = new InlineText(day.date.toString());
 				text.color = dayColor(day.day);
 				return text;
 			}),
@@ -36,9 +36,8 @@ export default SimpleSlashCommandBuilder.create(
 	];
 	const canvas = createCanvas(800, 400);
 	const ctx = canvas.getContext('2d');
-	ctx.fillStyle = 'white';
-	ctx.fillRect(0, 0, 800, 400);
-	const canvasTable = new CanvasTable(table, new BoundingBox(50, 50, 750, 350));
+	new BoundingBox(0, 0, 800, 400).fill(ctx, 'white');
+	const canvasTable = new CanvasTable(table, new BoundingBox(50, 50, 700, 300));
 	canvasTable.color = 'black';
 	canvasTable.renderTo(ctx);
 	await interaction.reply({

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -10,14 +10,20 @@ import {
 	InlineText,
 } from '../util/canvasUtils';
 
+const WORKDAY_COLOR = 'black';
+const HOLIDAY_COLOR = 'red';
+const SUNDAY_COLOR = 'red';
+const SATURDAY_COLOR = 'blue';
+const EXCLUDED_COLOR = 'gray';
+
 function dayColor(day: DayOfWeek) {
 	switch (day) {
 		case DayOfWeek.Sunday:
-			return 'red';
+			return SUNDAY_COLOR;
 		case DayOfWeek.Saturday:
-			return 'blue';
+			return SATURDAY_COLOR;
 		default:
-			return 'black';
+			return WORKDAY_COLOR;
 	}
 }
 
@@ -68,8 +74,11 @@ export default SimpleSlashCommandBuilder.create(
 				week.map((day) => {
 					const text = new InlineText(day.date.toString());
 					text.color = dayColor(day.day);
+					if (day.isHoliday()) {
+						text.color = HOLIDAY_COLOR;
+					}
 					if (!calendar.includes(day)) {
-						text.color = 'gray';
+						text.color = EXCLUDED_COLOR;
 					}
 					if (day.is(today)) {
 						text.font = `bold 24px ${FONT_FAMILY}`;

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -13,7 +13,6 @@ export default SimpleSlashCommandBuilder.create(
 		week.map((day) => day.date.toString().padStart(2)),
 	);
 	const table = [LANG.commands.cal.dayLabels, ...days];
-	console.log(table);
 	const canvas = createCanvas(800, 400);
 	const ctx = canvas.getContext('2d');
 	ctx.fillStyle = 'white';

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -1,5 +1,5 @@
 import { SimpleSlashCommandBuilder } from '../../../common/SimpleCommand';
-import { Day, MonthCalendar } from '../util/calendar';
+import { DayOfWeek, MonthCalendar } from '../util/calendar';
 
 export default SimpleSlashCommandBuilder.create(
 	'cal',
@@ -7,28 +7,27 @@ export default SimpleSlashCommandBuilder.create(
 ).build(async (interaction) => {
 	const calendar = new MonthCalendar();
 	const dates = [];
-	const size = calendar.size;
-	for (let i = 1; i <= size; i++) {
-		dates.push(`${dayToString(calendar.dayOf(i))} ${String(i).padStart(2)}`);
+	for (const day of calendar.days()) {
+		dates.push(`${dayToString(day.day)} ${String(day.date).padStart(2)}`);
 	}
 	await interaction.reply('```' + dates.join('\n') + '```');
 });
 
-function dayToString(day: Day) {
+function dayToString(day: DayOfWeek) {
 	switch (day) {
-		case Day.Sunday:
+		case DayOfWeek.Sunday:
 			return 'Su';
-		case Day.Monday:
+		case DayOfWeek.Monday:
 			return 'Mo';
-		case Day.Tuesday:
+		case DayOfWeek.Tuesday:
 			return 'Tu';
-		case Day.Wednesday:
+		case DayOfWeek.Wednesday:
 			return 'We';
-		case Day.Thursday:
+		case DayOfWeek.Thursday:
 			return 'Th';
-		case Day.Friday:
+		case DayOfWeek.Friday:
 			return 'Fr';
-		case Day.Saturday:
+		case DayOfWeek.Saturday:
 			return 'Sa';
 	}
 }

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -1,22 +1,40 @@
+import { createCanvas } from 'canvas';
 import { SimpleSlashCommandBuilder } from '../../../common/SimpleCommand';
 import { LANG } from '../../../util/languages';
 import { MonthCalendar } from '../util/calendar';
+import { BoundingBox, CanvasTable } from '../util/canvasUtils';
 
 export default SimpleSlashCommandBuilder.create(
 	LANG.commands.cal.name,
 	LANG.commands.cal.description,
 ).build(async (interaction) => {
 	const calendar = new MonthCalendar();
-	const days = Array.from(calendar.weeks())
-		.map((week) =>
-			week
-				.map((day) =>
-					calendar.includes(day) ? String(day.date).padStart(2) : '  ',
-				)
-				.join(' '),
-		)
-		.join('\n');
-	await interaction.reply(
-		'```' + LANG.commands.cal.dayLabels.join(' ') + '\n' + days + '```',
+	const days = Array.from(calendar.weeks()).map((week) =>
+		week.map((day) => day.date.toString().padStart(2)),
 	);
+	const table = [LANG.commands.cal.dayLabels, ...days];
+	console.log(table);
+	const canvas = createCanvas(800, 400);
+	const ctx = canvas.getContext('2d');
+	ctx.fillStyle = 'white';
+	ctx.fillRect(0, 0, 800, 400);
+	const canvasTable = new CanvasTable(table, new BoundingBox(0, 0, 800, 400));
+	canvasTable.color = 'black';
+	canvasTable.renderTo(ctx);
+	await interaction.reply({
+		files: [
+			{
+				attachment: canvas.toBuffer(),
+				name: 'calendar.png',
+			},
+		],
+		embeds: [
+			{
+				title: 'カレンダー',
+				image: {
+					url: 'attachment://calendar.png',
+				},
+			},
+		],
+	});
 });

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -1,11 +1,34 @@
 import { SimpleSlashCommandBuilder } from '../../../common/SimpleCommand';
+import { Day, MonthCalendar } from '../util/calendar';
 
 export default SimpleSlashCommandBuilder.create(
 	'cal',
 	'カレンダーを表示します',
 ).build(async (interaction) => {
-	await interaction.reply({
-		content: '開発中',
-		ephemeral: true,
-	});
+	const calendar = new MonthCalendar();
+	const dates = [];
+	const size = calendar.size;
+	for (let i = 1; i <= size; i++) {
+		dates.push(`${dayToString(calendar.dayOf(i))} ${String(i).padStart(2)}`);
+	}
+	await interaction.reply('```' + dates.join('\n') + '```');
 });
+
+function dayToString(day: Day) {
+	switch (day) {
+		case Day.Sunday:
+			return 'Su';
+		case Day.Monday:
+			return 'Mo';
+		case Day.Tuesday:
+			return 'Tu';
+		case Day.Wednesday:
+			return 'We';
+		case Day.Thursday:
+			return 'Th';
+		case Day.Friday:
+			return 'Fr';
+		case Day.Saturday:
+			return 'Sa';
+	}
+}

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -24,55 +24,88 @@ function dayColor(day: DayOfWeek) {
 export default SimpleSlashCommandBuilder.create(
 	LANG.commands.cal.name,
 	LANG.commands.cal.description,
-).build(async (interaction) => {
-	const calendar = new MonthCalendar();
-	const today = new Date();
-	const table = [
-		LANG.commands.cal.dayLabels.map((e, i) => {
-			const text = new InlineText(e);
-			text.color = dayColor(i as DayOfWeek);
-			return text;
-		}),
-		...Array.from(calendar.weeks()).map((week) =>
-			week.map((day) => {
-				const text = new InlineText(day.date.toString());
-				text.color = dayColor(day.day);
-				if (!calendar.includes(day)) {
-					text.color = 'gray';
-				}
-				if (day.is(today)) {
-					text.font = `bold 24px ${FONT_FAMILY}`;
-				}
+)
+	.addIntegerOption({
+		name: LANG.commands.cal.options.month.name,
+		description: LANG.commands.cal.options.month.description,
+		choices: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11].map((value) => ({
+			name: LANG.commands.cal.monthNames[value],
+			value,
+		})),
+		required: false,
+	})
+	.addIntegerOption({
+		name: LANG.commands.cal.options.year.name,
+		description: LANG.commands.cal.options.year.description,
+		required: false,
+	})
+	.addIntegerOption({
+		name: LANG.commands.cal.options.weekStart.name,
+		description: LANG.commands.cal.options.weekStart.description,
+		choices: Object.values(DayOfWeek).map((value) => ({
+			name: LANG.commands.cal.dayNames[value],
+			value,
+		})),
+		required: false,
+	})
+	.build(async (interaction, month, year, weekStart = DayOfWeek.Sunday) => {
+		const today = new Date();
+		const calendar = new MonthCalendar(
+			month ?? today.getMonth(),
+			year ?? today.getFullYear(),
+		);
+		const days = [];
+		for (let i = 0; i < 7; i++) {
+			days.push((weekStart + i) % 7);
+		}
+		const table = [
+			days.map((i) => {
+				const text = new InlineText(LANG.commands.cal.dayLabels[i]);
+				text.color = dayColor(i as DayOfWeek);
 				return text;
 			}),
-		),
-	];
-	const canvas = createCanvas(800, 400);
-	const ctx = canvas.getContext('2d');
-	new BoundingBox(0, 0, 800, 400).fill(ctx, 'white');
-	const title = strFormat(LANG.commands.cal.monthYear, {
-		month: LANG.commands.cal.monthNames[calendar.month],
-		year: calendar.year,
-	});
-	const titleStyle = new InlineText(title);
-	titleStyle.color = 'black';
-	titleStyle.font = `48px ${FONT_FAMILY}`;
-	new CanvasTextBox(titleStyle, new BoundingBox(50, 0, 700, 100)).renderTo(ctx);
-	new CanvasTable(table, new BoundingBox(50, 100, 700, 300)).renderTo(ctx);
-	await interaction.reply({
-		files: [
-			{
-				attachment: canvas.toBuffer(),
-				name: 'calendar.png',
-			},
-		],
-		embeds: [
-			{
-				title: strFormat(title),
-				image: {
-					url: 'attachment://calendar.png',
+			...Array.from(calendar.weeks(weekStart)).map((week) =>
+				week.map((day) => {
+					const text = new InlineText(day.date.toString());
+					text.color = dayColor(day.day);
+					if (!calendar.includes(day)) {
+						text.color = 'gray';
+					}
+					if (day.is(today)) {
+						text.font = `bold 24px ${FONT_FAMILY}`;
+					}
+					return text;
+				}),
+			),
+		];
+		const canvas = createCanvas(800, 400);
+		const ctx = canvas.getContext('2d');
+		new BoundingBox(0, 0, 800, 400).fill(ctx, 'white');
+		const title = strFormat(LANG.commands.cal.monthYear, {
+			month: LANG.commands.cal.monthNames[calendar.month],
+			year: calendar.year,
+		});
+		const titleStyle = new InlineText(title);
+		titleStyle.color = 'black';
+		titleStyle.font = `48px ${FONT_FAMILY}`;
+		new CanvasTextBox(titleStyle, new BoundingBox(50, 0, 700, 100)).renderTo(
+			ctx,
+		);
+		new CanvasTable(table, new BoundingBox(50, 100, 700, 300)).renderTo(ctx);
+		await interaction.reply({
+			files: [
+				{
+					attachment: canvas.toBuffer(),
+					name: 'calendar.png',
 				},
-			},
-		],
+			],
+			embeds: [
+				{
+					title: strFormat(title),
+					image: {
+						url: 'attachment://calendar.png',
+					},
+				},
+			],
+		});
 	});
-});

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -6,6 +6,7 @@ import {
 	BoundingBox,
 	CanvasTable,
 	CanvasTextBox,
+	FONT_FAMILY,
 	InlineText,
 } from '../util/canvasUtils';
 
@@ -40,7 +41,7 @@ export default SimpleSlashCommandBuilder.create(
 					text.color = 'gray';
 				}
 				if (day.is(today)) {
-					text.font = 'bold 24px serif';
+					text.font = `bold 24px ${FONT_FAMILY}`;
 				}
 				return text;
 			}),
@@ -55,7 +56,7 @@ export default SimpleSlashCommandBuilder.create(
 	});
 	const titleStyle = new InlineText(title);
 	titleStyle.color = 'black';
-	titleStyle.font = '48px serif';
+	titleStyle.font = `48px ${FONT_FAMILY}`;
 	new CanvasTextBox(titleStyle, new BoundingBox(50, 0, 700, 100)).renderTo(ctx);
 	new CanvasTable(table, new BoundingBox(50, 100, 700, 300)).renderTo(ctx);
 	await interaction.reply({

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -1,23 +1,44 @@
 import { createCanvas } from 'canvas';
 import { SimpleSlashCommandBuilder } from '../../../common/SimpleCommand';
 import { LANG } from '../../../util/languages';
-import { MonthCalendar } from '../util/calendar';
-import { BoundingBox, CanvasTable } from '../util/canvasUtils';
+import { DayOfWeek, MonthCalendar } from '../util/calendar';
+import { BoundingBox, CanvasTable, InlineText } from '../util/canvasUtils';
+
+function dayColor(day: DayOfWeek) {
+	switch (day) {
+		case DayOfWeek.Sunday:
+			return 'red';
+		case DayOfWeek.Saturday:
+			return 'blue';
+		default:
+			return 'black';
+	}
+}
 
 export default SimpleSlashCommandBuilder.create(
 	LANG.commands.cal.name,
 	LANG.commands.cal.description,
 ).build(async (interaction) => {
 	const calendar = new MonthCalendar();
-	const days = Array.from(calendar.weeks()).map((week) =>
-		week.map((day) => day.date.toString().padStart(2)),
-	);
-	const table = [LANG.commands.cal.dayLabels, ...days];
+	const table = [
+		LANG.commands.cal.dayLabels.map((e, i) => {
+			const text = new InlineText(e);
+			text.color = dayColor(i as DayOfWeek);
+			return text;
+		}),
+		...Array.from(calendar.weeks()).map((week) =>
+			week.map((day) => {
+				const text = new InlineText(day.date.toString().padStart(2));
+				text.color = dayColor(day.day);
+				return text;
+			}),
+		),
+	];
 	const canvas = createCanvas(800, 400);
 	const ctx = canvas.getContext('2d');
 	ctx.fillStyle = 'white';
 	ctx.fillRect(0, 0, 800, 400);
-	const canvasTable = new CanvasTable(table, new BoundingBox(0, 0, 800, 400));
+	const canvasTable = new CanvasTable(table, new BoundingBox(50, 50, 750, 350));
 	canvasTable.color = 'black';
 	canvasTable.renderTo(ctx);
 	await interaction.reply({

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -1,33 +1,19 @@
 import { SimpleSlashCommandBuilder } from '../../../common/SimpleCommand';
-import { DayOfWeek, MonthCalendar } from '../util/calendar';
+import { MonthCalendar } from '../util/calendar';
 
 export default SimpleSlashCommandBuilder.create(
 	'cal',
 	'カレンダーを表示します',
 ).build(async (interaction) => {
 	const calendar = new MonthCalendar();
-	const dates = [];
-	for (const day of calendar.days()) {
-		dates.push(`${dayToString(day.day)} ${String(day.date).padStart(2)}`);
-	}
-	await interaction.reply('```' + dates.join('\n') + '```');
+	const days = Array.from(calendar.weeks())
+		.map((week) =>
+			week
+				.map((day) =>
+					calendar.includes(day) ? String(day.date).padStart(2) : '  ',
+				)
+				.join(' '),
+		)
+		.join('\n');
+	await interaction.reply('```Su Mo Tu We Th Fr Sa\n' + days + '```');
 });
-
-function dayToString(day: DayOfWeek) {
-	switch (day) {
-		case DayOfWeek.Sunday:
-			return 'Su';
-		case DayOfWeek.Monday:
-			return 'Mo';
-		case DayOfWeek.Tuesday:
-			return 'Tu';
-		case DayOfWeek.Wednesday:
-			return 'We';
-		case DayOfWeek.Thursday:
-			return 'Th';
-		case DayOfWeek.Friday:
-			return 'Fr';
-		case DayOfWeek.Saturday:
-			return 'Sa';
-	}
-}

--- a/packages/misc/commands/cal.ts
+++ b/packages/misc/commands/cal.ts
@@ -1,0 +1,11 @@
+import { SimpleSlashCommandBuilder } from '../../../common/SimpleCommand';
+
+export default SimpleSlashCommandBuilder.create(
+	'cal',
+	'カレンダーを表示します',
+).build(async (interaction) => {
+	await interaction.reply({
+		content: '開発中',
+		ephemeral: true,
+	});
+});

--- a/packages/misc/index.js
+++ b/packages/misc/index.js
@@ -2,9 +2,11 @@ const fs = require('fs');
 const path = require('path');
 
 const { CommandManager } = require('../../internal/commands');
+const { registerConfiguredFont } = require('./util/canvasUtils');
 
 class MiscFeature {
 	onLoad() {
+		registerConfiguredFont();
 		fs.readdirSync(path.join(__dirname, 'commands'), {
 			withFileTypes: true,
 		}).forEach((file) => {

--- a/packages/misc/index.js
+++ b/packages/misc/index.js
@@ -10,7 +10,10 @@ class MiscFeature {
 		}).forEach((file) => {
 			const ext = path.extname(file.name);
 			if (!file.isFile() || (ext != '.js' && ext != '.ts')) return;
-			const cmds = require(path.join(__dirname, 'commands', file.name));
+			let cmds = require(path.join(__dirname, 'commands', file.name));
+			if ('default' in cmds) {
+				cmds = cmds.default;
+			}
 			CommandManager.default.addCommands(cmds);
 		});
 	}

--- a/packages/misc/util/calendar.ts
+++ b/packages/misc/util/calendar.ts
@@ -1,4 +1,4 @@
-export const Day = Object.freeze({
+export const DayOfWeek = Object.freeze({
 	Sunday: 0,
 	Monday: 1,
 	Tuesday: 2,
@@ -8,7 +8,25 @@ export const Day = Object.freeze({
 	Saturday: 6,
 });
 
-export type Day = (typeof Day)[keyof typeof Day];
+export type DayOfWeek = (typeof DayOfWeek)[keyof typeof DayOfWeek];
+
+export class Day {
+	public readonly year: number;
+
+	public readonly month: number;
+
+	public readonly date: number;
+
+	public readonly day: DayOfWeek;
+
+	constructor(year: number, monthIndex: number, date: number) {
+		const dateObj = new Date(year, monthIndex, date);
+		this.year = dateObj.getFullYear();
+		this.month = dateObj.getMonth();
+		this.date = dateObj.getDate();
+		this.day = dateObj.getDay() as DayOfWeek;
+	}
+}
 
 export class MonthCalendar {
 	public readonly month: number;
@@ -16,9 +34,6 @@ export class MonthCalendar {
 	public readonly year: number;
 
 	public readonly size: number;
-
-	/** 0日 (1日の前日) の曜日 */
-	private readonly baseDay: Day;
 
 	/**
 	 * 月のカレンダーを作成する。
@@ -36,10 +51,12 @@ export class MonthCalendar {
 		this.month = monthIndex;
 		this.year = year;
 		this.size = new Date(year, monthIndex + 1, 0).getDate();
-		this.baseDay = new Date(year, monthIndex, 0).getDay() as Day;
 	}
 
-	dayOf(date: number): Day {
-		return ((this.baseDay + date) % 7) as Day;
+	*days(): Iterable<Day> {
+		const size = this.size;
+		for (let date = 1; date <= size; date++) {
+			yield new Day(this.year, this.month, date);
+		}
 	}
 }

--- a/packages/misc/util/calendar.ts
+++ b/packages/misc/util/calendar.ts
@@ -26,7 +26,13 @@ export class Day {
 		this.date = dateObj.getDate();
 		this.day = dateObj.getDay() as DayOfWeek;
 	}
+
+	add(days: number) {
+		return new Day(this.year, this.month, this.date + days);
+	}
 }
+
+export type Week = { [K in DayOfWeek]: Day } & Array<Day>;
 
 export class MonthCalendar {
 	public readonly month: number;
@@ -53,10 +59,28 @@ export class MonthCalendar {
 		this.size = new Date(year, monthIndex + 1, 0).getDate();
 	}
 
-	*days(): Iterable<Day> {
-		const size = this.size;
-		for (let date = 1; date <= size; date++) {
-			yield new Day(this.year, this.month, date);
+	firstDay() {
+		return new Day(this.year, this.month, 1);
+	}
+
+	includes(day: Day) {
+		if (day.year == this.year && day.month == this.month) {
+			return true;
 		}
+	}
+
+	*weeks(): Iterable<Week> {
+		const monthFirst = this.firstDay();
+		let weekFirst = monthFirst.add(-monthFirst.day);
+		do {
+			const week = [weekFirst];
+			let day = weekFirst;
+			for (let i = 1; i < 7; i++) {
+				day = day.add(1);
+				week[i] = day;
+			}
+			yield week as Week;
+			weekFirst = weekFirst.add(7);
+		} while (this.includes(weekFirst));
 	}
 }

--- a/packages/misc/util/calendar.ts
+++ b/packages/misc/util/calendar.ts
@@ -1,0 +1,45 @@
+export const Day = Object.freeze({
+	Sunday: 0,
+	Monday: 1,
+	Tuesday: 2,
+	Wednesday: 3,
+	Thursday: 4,
+	Friday: 5,
+	Saturday: 6,
+});
+
+export type Day = (typeof Day)[keyof typeof Day];
+
+export class MonthCalendar {
+	public readonly month: number;
+
+	public readonly year: number;
+
+	public readonly size: number;
+
+	/** 0日 (1日の前日) の曜日 */
+	private readonly baseDay: Day;
+
+	/**
+	 * 月のカレンダーを作成する。
+	 * @param monthIndex 0始まりの月の番号 (0～11)
+	 * @param year 西暦
+	 */
+	constructor(monthIndex?: number, year?: number) {
+		if (year == null) {
+			const date = new Date();
+			year = date.getFullYear();
+			if (monthIndex == null) {
+				monthIndex = date.getMonth();
+			}
+		}
+		this.month = monthIndex;
+		this.year = year;
+		this.size = new Date(year, monthIndex + 1, 0).getDate();
+		this.baseDay = new Date(year, monthIndex, 0).getDay() as Day;
+	}
+
+	dayOf(date: number): Day {
+		return ((this.baseDay + date) % 7) as Day;
+	}
+}

--- a/packages/misc/util/calendar.ts
+++ b/packages/misc/util/calendar.ts
@@ -77,9 +77,13 @@ export class MonthCalendar {
 		}
 	}
 
-	*weeks(): Iterable<Week> {
+	*weeks(weekStart: DayOfWeek = DayOfWeek.Sunday): Iterable<Week> {
 		const monthFirst = this.firstDay();
-		let weekFirst = monthFirst.add(-monthFirst.day);
+		let firstDate = weekStart - monthFirst.day + 7; // カレンダーの最初の日付 (1日以前、負になり得る)
+		while (firstDate > 1) {
+			firstDate -= 7;
+		}
+		let weekFirst = monthFirst.add(firstDate);
 		do {
 			const week = [weekFirst];
 			let day = weekFirst;

--- a/packages/misc/util/calendar.ts
+++ b/packages/misc/util/calendar.ts
@@ -30,6 +30,14 @@ export class Day {
 	add(days: number) {
 		return new Day(this.year, this.month, this.date + days);
 	}
+
+	is(date: Date): boolean {
+		return (
+			this.year == date.getFullYear() &&
+			this.month == date.getMonth() &&
+			this.date == date.getDate()
+		);
+	}
 }
 
 export type Week = { [K in DayOfWeek]: Day } & Array<Day>;

--- a/packages/misc/util/canvasUtils.ts
+++ b/packages/misc/util/canvasUtils.ts
@@ -1,10 +1,22 @@
-import { CanvasRenderingContext2D } from 'canvas';
+import { CanvasRenderingContext2D, registerFont } from 'canvas';
+import config from '../../../config.json';
+
+const FONT_FILE = config.fontFile ?? 'font.ttf';
+export const FONT_FAMILY = config.fontFamily ?? 'serif';
 
 function requireNonnegative(x: number, name: string): number {
 	if (x < 0) {
 		throw new RangeError(`${name} must not be less than ${x}`);
 	}
 	return x;
+}
+
+export function registerConfiguredFont() {
+	try {
+		registerFont(FONT_FILE, { family: FONT_FAMILY });
+	} catch (e) {
+		console.error(e);
+	}
 }
 
 export class BoundingBox {
@@ -43,7 +55,7 @@ export class InlineText {
 
 	public color: string = 'black';
 
-	public font: string = '24px serif';
+	public font: string = `24px ${FONT_FAMILY}`;
 
 	constructor(text: string) {
 		this.text = text;

--- a/packages/misc/util/canvasUtils.ts
+++ b/packages/misc/util/canvasUtils.ts
@@ -1,5 +1,4 @@
-import { CanvasRenderingContext2D, CanvasTextBaseline } from 'canvas';
-import { formatTable } from '../../../util/strings';
+import { CanvasRenderingContext2D } from 'canvas';
 
 function requireNonnegative(x: number, name: string): number {
 	if (x < 0) {
@@ -22,6 +21,20 @@ export class BoundingBox {
 		this.y = requireNonnegative(y, 'y');
 		this.width = requireNonnegative(width, 'width');
 		this.height = requireNonnegative(height, 'height');
+	}
+
+	stroke(ctx: CanvasRenderingContext2D, color: string) {
+		ctx.save();
+		ctx.strokeStyle = color;
+		ctx.strokeRect(this.x, this.y, this.width, this.height);
+		ctx.restore();
+	}
+
+	fill(ctx: CanvasRenderingContext2D, color: string) {
+		ctx.save();
+		ctx.fillStyle = color;
+		ctx.fillRect(this.x, this.y, this.width, this.height);
+		ctx.restore();
 	}
 }
 
@@ -55,6 +68,10 @@ export class CanvasTextBox {
 
 	public boundingBox: BoundingBox;
 
+	public align: 'center' = 'center';
+
+	public verticalAlign: 'middle' = 'middle';
+
 	constructor(text: InlineText, boundingBox: BoundingBox) {
 		this.text = text;
 		this.boundingBox = boundingBox;
@@ -63,8 +80,26 @@ export class CanvasTextBox {
 	renderTo(ctx: CanvasRenderingContext2D) {
 		ctx.save();
 		ctx.textBaseline = 'top';
-		this.text.renderTo(ctx, this.boundingBox.x, this.boundingBox.y);
+		ctx.textAlign = this.align;
+		ctx.textBaseline = this.verticalAlign;
+		this.text.renderTo(ctx, this.getX(), this.getY());
 		ctx.restore();
+	}
+
+	private getX() {
+		const boundingBox = this.boundingBox;
+		switch (this.align) {
+			case 'center':
+				return boundingBox.x + boundingBox.width / 2;
+		}
+	}
+
+	private getY() {
+		const boundingBox = this.boundingBox;
+		switch (this.verticalAlign) {
+			case 'middle':
+				return boundingBox.y + boundingBox.height / 2;
+		}
 	}
 }
 
@@ -88,8 +123,8 @@ export class CanvasTable {
 						new BoundingBox(
 							boundingBox.x + cellWidth * j,
 							boundingBox.y + cellHeight * i,
-							boundingBox.width,
-							boundingBox.height,
+							cellWidth,
+							cellHeight,
 						),
 					),
 			),

--- a/packages/misc/util/canvasUtils.ts
+++ b/packages/misc/util/canvasUtils.ts
@@ -1,0 +1,52 @@
+import { CanvasRenderingContext2D } from 'canvas';
+import { formatTable } from '../../../util/strings';
+
+function requireNonnegative(x: number, name: string): number {
+	if (x < 0) {
+		throw new RangeError(`${name} must not be less than ${x}`);
+	}
+	return x;
+}
+
+export class BoundingBox {
+	readonly x: number;
+
+	readonly y: number;
+
+	readonly width: number;
+
+	readonly height: number;
+
+	constructor(x: number, y: number, width: number, height: number) {
+		this.x = requireNonnegative(x, 'x');
+		this.y = requireNonnegative(y, 'y');
+		this.width = requireNonnegative(width, 'width');
+		this.height = requireNonnegative(height, 'height');
+	}
+}
+
+export class CanvasTable {
+	private cells: string[][];
+
+	private boundingBox: BoundingBox;
+
+	public color: string;
+
+	constructor(cells: string[][], boundingBox: BoundingBox) {
+		this.cells = cells;
+		this.boundingBox = boundingBox;
+	}
+
+	renderTo(ctx: CanvasRenderingContext2D) {
+		ctx.save();
+		ctx.font = '48px monospace';
+		ctx.fillStyle = this.color;
+		ctx.textBaseline = 'top';
+		ctx.fillText(
+			formatTable(this.cells),
+			this.boundingBox.x,
+			this.boundingBox.y,
+		);
+		ctx.restore();
+	}
+}

--- a/packages/misc/util/canvasUtils.ts
+++ b/packages/misc/util/canvasUtils.ts
@@ -25,28 +25,63 @@ export class BoundingBox {
 	}
 }
 
+export class CanvasTextBox {
+	public text: string;
+
+	public boundingBox: BoundingBox;
+
+	public color: string;
+
+	constructor(text: string, boundingBox: BoundingBox) {
+		this.text = text;
+		this.boundingBox = boundingBox;
+	}
+
+	renderTo(ctx: CanvasRenderingContext2D) {
+		ctx.save();
+		ctx.font = '24px serif';
+		ctx.fillStyle = this.color;
+		ctx.textBaseline = 'top';
+		ctx.fillText(this.text, this.boundingBox.x, this.boundingBox.y);
+		ctx.restore();
+	}
+}
+
 export class CanvasTable {
-	private cells: string[][];
+	private cells: CanvasTextBox[][];
 
 	private boundingBox: BoundingBox;
 
 	public color: string;
 
 	constructor(cells: string[][], boundingBox: BoundingBox) {
-		this.cells = cells;
+		const rowCount = cells.length;
+		const columnCount = cells[0].length;
+		const cellWidth = boundingBox.width / columnCount;
+		const cellHeight = boundingBox.height / rowCount;
+		this.cells = cells.map((row, i) =>
+			row.map(
+				(cell, j) =>
+					new CanvasTextBox(
+						cell,
+						new BoundingBox(
+							boundingBox.x + cellWidth * j,
+							boundingBox.y + cellHeight * i,
+							boundingBox.width,
+							boundingBox.height,
+						),
+					),
+			),
+		);
 		this.boundingBox = boundingBox;
 	}
 
 	renderTo(ctx: CanvasRenderingContext2D) {
-		ctx.save();
-		ctx.font = '48px monospace';
-		ctx.fillStyle = this.color;
-		ctx.textBaseline = 'top';
-		ctx.fillText(
-			formatTable(this.cells),
-			this.boundingBox.x,
-			this.boundingBox.y,
-		);
-		ctx.restore();
+		for (const row of this.cells) {
+			for (const cell of row) {
+				cell.color = this.color;
+				cell.renderTo(ctx);
+			}
+		}
 	}
 }

--- a/packages/misc/util/canvasUtils.ts
+++ b/packages/misc/util/canvasUtils.ts
@@ -1,4 +1,4 @@
-import { CanvasRenderingContext2D } from 'canvas';
+import { CanvasRenderingContext2D, CanvasTextBaseline } from 'canvas';
 import { formatTable } from '../../../util/strings';
 
 function requireNonnegative(x: number, name: string): number {
@@ -25,24 +25,45 @@ export class BoundingBox {
 	}
 }
 
-export class CanvasTextBox {
+export class InlineText {
 	public text: string;
+
+	public color: string = 'black';
+
+	public font: string = '24px serif';
+
+	constructor(text: string) {
+		this.text = text;
+	}
+
+	renderTo(
+		ctx: CanvasRenderingContext2D,
+		x: number,
+		y: number,
+		maxWidth?: number,
+	) {
+		ctx.save();
+		ctx.fillStyle = this.color;
+		ctx.font = this.font;
+		ctx.fillText(this.text, x, y, maxWidth);
+		ctx.restore();
+	}
+}
+
+export class CanvasTextBox {
+	public text: InlineText;
 
 	public boundingBox: BoundingBox;
 
-	public color: string;
-
-	constructor(text: string, boundingBox: BoundingBox) {
+	constructor(text: InlineText, boundingBox: BoundingBox) {
 		this.text = text;
 		this.boundingBox = boundingBox;
 	}
 
 	renderTo(ctx: CanvasRenderingContext2D) {
 		ctx.save();
-		ctx.font = '24px serif';
-		ctx.fillStyle = this.color;
 		ctx.textBaseline = 'top';
-		ctx.fillText(this.text, this.boundingBox.x, this.boundingBox.y);
+		this.text.renderTo(ctx, this.boundingBox.x, this.boundingBox.y);
 		ctx.restore();
 	}
 }
@@ -54,7 +75,7 @@ export class CanvasTable {
 
 	public color: string;
 
-	constructor(cells: string[][], boundingBox: BoundingBox) {
+	constructor(cells: InlineText[][], boundingBox: BoundingBox) {
 		const rowCount = cells.length;
 		const columnCount = cells[0].length;
 		const cellWidth = boundingBox.width / columnCount;
@@ -79,7 +100,6 @@ export class CanvasTable {
 	renderTo(ctx: CanvasRenderingContext2D) {
 		for (const row of this.cells) {
 			for (const cell of row) {
-				cell.color = this.color;
 				cell.renderTo(ctx);
 			}
 		}


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
#54 で提案された機能のうち、/dateコマンドを実装しました。
プロジェクトルートにフォントファイルを設置して、config.jsonの`fontFile`にファイル名を指定することでフォントを使用できます。
/dateコマンドは実装してないのでまだ #54 は**閉じません**。

## 変更点

<!--- 変更点の記述 -->
- `misc` パッケージに/dateコマンドを追加
- `misc` パッケージに `calendar.ts`, `canvasUtils.ts` を作成
- `fontFile`, `fontFamily` 設定項目の追加

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
