### PR TITLE
/uploadコマンドが一部ファイルに対応していない問題を修正 (#77)

### DIFF
--- a/packages/cdn/upload.ts
+++ b/packages/cdn/upload.ts
@@ -1,10 +1,10 @@
-const { SlashCommandBuilder } = require('discord.js');
+import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
 const axios = require('axios').default;
 const FormData = require('form-data');
 const config = require('../../config.json');
 const { LANG, strFormat } = require('../../util/languages');
 
-module.exports = {
+export default {
 	data: new SlashCommandBuilder()
 		.setName(LANG.commands.upload.name)
 		.setDescription(LANG.commands.upload.description)
@@ -25,10 +25,7 @@ module.exports = {
 				.setDescription(LANG.commands.upload.options.private.description)
 				.setRequired(false),
 		),
-	execute: async function (
-		/** @type {import('discord.js').CommandInteraction} */
-		interaction,
-	) {
+	execute: async function (interaction: ChatInputCommandInteraction) {
 		if (!config.cdnUploadURL || !config.uploadAllowUsers) {
 			await interaction.reply(LANG.commands.upload.internalError);
 			return;

--- a/packages/cdn/upload.ts
+++ b/packages/cdn/upload.ts
@@ -1,8 +1,8 @@
 import { ChatInputCommandInteraction, SlashCommandBuilder } from 'discord.js';
-const axios = require('axios').default;
-const FormData = require('form-data');
-const config = require('../../config.json');
-const { LANG, strFormat } = require('../../util/languages');
+import axios from 'axios';
+import FormData from 'form-data';
+import config from '../../internal/config';
+import { LANG, strFormat } from '../../util/languages';
 
 export default {
 	data: new SlashCommandBuilder()
@@ -47,12 +47,13 @@ export default {
 				responseType: 'stream',
 			});
 			const form = new FormData();
-			const filename = interaction.options.get(
+			const filename = interaction.options.getString(
 				LANG.commands.upload.options.filename.name,
-			)?.value;
+			);
 			const isPrivate =
-				interaction.options.get(LANG.commands.upload.options.private.name)
-					?.value == true;
+				interaction.options.getBoolean(
+					LANG.commands.upload.options.private.name,
+				) == true;
 			console.log(strFormat(LANG.commands.upload.isPrivateLog, [isPrivate]));
 			form.append('file', res.data, filename || file.name);
 			const res2 = await axios.post(config.cdnUploadURL, form, {

--- a/packages/cdn/upload.ts
+++ b/packages/cdn/upload.ts
@@ -43,9 +43,8 @@ export default {
 		);
 
 		try {
-			const res = await axios.get(file.proxyURL, {
-				responseType: 'stream',
-			});
+			const res = await fetch(file.url);
+			const resData = await res.arrayBuffer();
 			const form = new FormData();
 			const filename = interaction.options.getString(
 				LANG.commands.upload.options.filename.name,
@@ -55,7 +54,7 @@ export default {
 					LANG.commands.upload.options.private.name,
 				) == true;
 			console.log(strFormat(LANG.commands.upload.isPrivateLog, [isPrivate]));
-			form.append('file', res.data, filename || file.name);
+			form.append('file', Buffer.from(resData), filename || file.name);
 			const res2 = await axios.post(config.cdnUploadURL, form, {
 				params: {
 					private: isPrivate,


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
どんな種類のファイルも /upload コマンドでアップロードできるようにします。
This PR will close #77.

## 変更点

<!--- 変更点の記述 -->
- upload.js も TypeScript にしちゃう
- Discord からの添付ファイルの取得を fetch で行う

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
