### PR TITLE
サーバーごとの権限管理システム (#92)

### DIFF
--- a/core/util/types.ts
+++ b/core/util/types.ts
@@ -1,4 +1,5 @@
 import {
+	AutocompleteInteraction,
 	ChatInputCommandInteraction,
 	Client,
 	RESTPostAPIChatInputApplicationCommandsJSONBody,
@@ -25,6 +26,11 @@ export interface Command {
 		interaction: ChatInputCommandInteraction,
 		client: Client<true>,
 	): Promise<void>;
+
+	/**
+	 * 自動補完の処理
+	 */
+	autocomplete?(interaction: AutocompleteInteraction): Promise<void>;
 }
 
 /**

--- a/language/default.json
+++ b/language/default.json
@@ -110,7 +110,9 @@
 			"result": "結果:",
 			"notPlayableError": "えー実行したくないなぁー...だってVCに君が居ないんだもん...",
 			"playerTrack": "${title} (${duration})",
-			"noTracksPlayed": "再生されている曲がありません！"
+			"noTracksPlayed": "再生されている曲がありません！",
+			"useCommandInGuild": "このコマンドはサーバー内で使用してください！",
+			"noPermission": "権限がありません！"
 		},
 		"defaultValues": {
 			"graphLabel": "value"
@@ -570,6 +572,40 @@
 			"playerPaused": "音楽を一時停止しました！",
 			"pauseFailed": "一時停止できませんでした"
 		},
+		"perm": {
+			"name": "perm",
+			"description": "権限の設定",
+			"subcommands": {
+				"set": {
+					"name": "set",
+					"description": "値の更新"
+				},
+				"get": {
+					"name": "get",
+					"description": "値の取得"
+				},
+				"remove": {
+					"name": "remove",
+					"description": "値の削除"
+				}
+			},
+			"options": {
+				"permission": {
+					"name": "permission",
+					"description": "権限名"
+				},
+				"group": {
+					"name": "group",
+					"description": "対象のロールまたはユーザー"
+				}
+			},
+			"noSuchPermission": ["権限名: ${0}", "その名前の権限はありません!"],
+			"permissionInformation": "権限情報",
+			"permissionName": "権限名",
+			"permissionGroup": "ロール/メンバー",
+			"permissionSet": "権限を追加しました!",
+			"permissionRemoved": "権限を削除しました"
+		},
 		"pieChart": {
 			"name": "piechart",
 			"description": "円グラフを生成します。",
@@ -701,6 +737,7 @@
 					"emptyMessage": "メッセージが設定されていません"
 				}
 			},
+			"replyCustomizePermission": "自動応答の設定",
 			"notInGuildError": "このコマンドはサーバー内でのみ使用できます！",
 			"permissionError": "このコマンドを使用する権限がありません！"
 		},

--- a/language/en.json
+++ b/language/en.json
@@ -110,7 +110,9 @@
 			"result": "Result:",
 			"notPlayableError": "Join the VC to execute the command!",
 			"playerTrack": "${title} (${duration})",
-			"noTracksPlayed": "There are no tracks played!"
+			"noTracksPlayed": "There are no tracks played!",
+			"useCommandInGuild": "Use this command in a server!",
+			"noPermission": "You have not permission to do it!"
 		},
 		"defaultValues": {
 			"graphLabel": "value"
@@ -539,6 +541,43 @@
 			"playerPaused": "Paused the player!",
 			"pauseFailed": "Failed to pause the player"
 		},
+		"perm": {
+			"name": "perm",
+			"description": "Permission configuration",
+			"subcommands": {
+				"set": {
+					"name": "set",
+					"description": "Updates a value"
+				},
+				"get": {
+					"name": "get",
+					"description": "Gets a value"
+				},
+				"remove": {
+					"name": "remove",
+					"description": "Removes a value"
+				}
+			},
+			"options": {
+				"permission": {
+					"name": "permission",
+					"description": "Permission name"
+				},
+				"group": {
+					"name": "group",
+					"description": "Target role or user"
+				}
+			},
+			"noSuchPermission": [
+				"Permission name: ${0}",
+				"There is not such permission!"
+			],
+			"permissionInformation": "Permission info",
+			"permissionName": "Permission name",
+			"permissionGroup": "Roles/Members",
+			"permissionSet": "Added a permission!",
+			"permissionRemoved": "Removed a permission"
+		},
 		"pieChart": {
 			"name": "piechart",
 			"description": "Generates a pie chart.",
@@ -670,6 +709,7 @@
 					"emptyMessage": "メッセージが設定されていません"
 				}
 			},
+			"replyCustomizePermission": "customizations of automatic replies",
 			"notInGuildError": "This commands must be used in a server!",
 			"permissionError": "You have not permission to use this command!"
 		},

--- a/language/ja.json
+++ b/language/ja.json
@@ -110,7 +110,9 @@
 			"result": "結果:",
 			"notPlayableError": "えー実行したくないなぁー…だってVCに君が居ないんだもん…",
 			"playerTrack": "${title} (${duration})",
-			"noTracksPlayed": "再生されている曲がありません！"
+			"noTracksPlayed": "再生されている曲がありません！",
+			"useCommandInGuild": "このコマンドはサーバー内で使用してください！",
+			"noPermission": "権限がありません！"
 		},
 		"defaultValues": {
 			"graphLabel": "value"
@@ -539,6 +541,40 @@
 			"playerPaused": "音楽を一時停止しました！",
 			"pauseFailed": "一時停止できませんでした"
 		},
+		"perm": {
+			"name": "perm",
+			"description": "権限の設定",
+			"subcommands": {
+				"set": {
+					"name": "set",
+					"description": "値の更新"
+				},
+				"get": {
+					"name": "get",
+					"description": "値の取得"
+				},
+				"remove": {
+					"name": "remove",
+					"description": "値の削除"
+				}
+			},
+			"options": {
+				"permission": {
+					"name": "permission",
+					"description": "権限名"
+				},
+				"group": {
+					"name": "group",
+					"description": "対象のロールまたはユーザー"
+				}
+			},
+			"noSuchPermission": ["権限名: ${0}", "その名前の権限はありません!"],
+			"permissionInformation": "権限情報",
+			"permissionName": "権限名",
+			"permissionGroup": "ロール/メンバー",
+			"permissionSet": "権限を追加しました!",
+			"permissionRemoved": "権限を削除しました"
+		},
 		"pieChart": {
 			"name": "piechart",
 			"description": "円グラフを生成します。",
@@ -670,6 +706,7 @@
 					"emptyMessage": "メッセージが設定されていません"
 				}
 			},
+			"replyCustomizePermission": "自動応答の設定",
 			"notInGuildError": "このコマンドはサーバー内でのみ使用できます！",
 			"permissionError": "このコマンドを使用する権限がありません！"
 		},

--- a/package-lock.json
+++ b/package-lock.json
@@ -5403,6 +5403,10 @@
 				"url": "https://github.com/sponsors/Borewit"
 			}
 		},
+		"node_modules/perms": {
+			"resolved": "packages/perms",
+			"link": true
+		},
 		"node_modules/picocolors": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -6919,6 +6923,11 @@
 			"devDependencies": {}
 		},
 		"packages/misc": {
+			"version": "1.0.0",
+			"license": "GPL-3.0-only",
+			"devDependencies": {}
+		},
+		"packages/perms": {
 			"version": "1.0.0",
 			"license": "GPL-3.0-only",
 			"devDependencies": {}

--- a/packages/misc/commands/reply.ts
+++ b/packages/misc/commands/reply.ts
@@ -4,7 +4,10 @@ import { LANG, Config, Command, Pager } from 'core';
 import { ClientMessageHandler, ReplyPattern } from '../util/messages';
 import { feature as perms } from 'perms';
 
-perms.registerPermission('replyCustomize', '自動応答の設定');
+perms.registerPermission(
+	'replyCustomize',
+	LANG.commands.reply.replyCustomizePermission,
+);
 
 module.exports = {
 	data: new SlashCommandBuilder()

--- a/packages/misc/commands/reply.ts
+++ b/packages/misc/commands/reply.ts
@@ -166,13 +166,9 @@ module.exports = {
 async function checkPermission(
 	interaction: ChatInputCommandInteraction<'cached'>,
 ) {
-	const replyCustomizePermission = await perms.permissions?.get(
-		interaction.guild,
-		'replyCustomize',
-	);
 	if (
 		interaction.member != null &&
-		replyCustomizePermission?.hasMember(interaction.member)
+		(await perms.hasPermission(interaction.member, 'replyCustomize'))
 	) {
 		return true;
 	}

--- a/packages/misc/commands/reply.ts
+++ b/packages/misc/commands/reply.ts
@@ -4,6 +4,8 @@ import { LANG, Config, Command, Pager } from 'core';
 import { ClientMessageHandler, ReplyPattern } from '../util/messages';
 import { feature as perms } from 'perms';
 
+perms.registerPermission('replyCustomize', '自動応答の設定');
+
 module.exports = {
 	data: new SlashCommandBuilder()
 		.setName(LANG.commands.reply.name)

--- a/packages/misc/index.ts
+++ b/packages/misc/index.ts
@@ -4,11 +4,14 @@ import path from 'path';
 
 import { Feature, CommandManager, Config } from 'core';
 import { Client } from 'discord.js';
+import { feature as perm } from 'perms';
 
 class MiscFeature extends Feature {
 	name = 'misc';
 
 	enabled = Config.features?.misc ?? true;
+
+	dependencies = [perm];
 
 	messageHandler?: ClientMessageHandler;
 

--- a/packages/perms/PermissionManager.ts
+++ b/packages/perms/PermissionManager.ts
@@ -1,0 +1,59 @@
+import { Client, Guild, GuildMember, Role, User } from 'discord.js';
+import { feature as db } from 'db';
+
+interface PermSchema {
+	client: string;
+	guild: string;
+	name: string;
+	group: string;
+}
+
+export type Mentionable = GuildMember | Role | User;
+
+export class PermissionManager {
+	static readonly #instances = new Map<string, PermissionManager>();
+
+	static forClient(client: Client<true>): PermissionManager {
+		const id = client.application.id;
+		const existing = PermissionManager.#instances.get(id);
+		if (existing != null) {
+			return existing;
+		}
+		const created = new PermissionManager(client);
+		PermissionManager.#instances.set(id, created);
+		return created;
+	}
+
+	readonly #client: Client<true>;
+
+	private constructor(client: Client<true>) {
+		this.#client = client;
+	}
+
+	async set(guild: Guild, name: string, group: Mentionable): Promise<void> {
+		const client = this.#client.application.id;
+		const connection = db.connection;
+		const collection = connection.collection<PermSchema>('perms');
+		const guildId = guild.id;
+		await collection.updateOne(
+			{ client, guild: guildId, name },
+			{ client, guild: guildId, name, group: group.id },
+		);
+	}
+
+	async get(guild: Guild, name: string): Promise<Mentionable | null> {
+		const client = this.#client.application.id;
+		const connection = db.connection;
+		const collection = connection.collection<PermSchema>('perms');
+		const result = await collection.findOne({ client, guild: guild.id, name });
+		if (result == null) {
+			return null;
+		}
+		const { group } = result;
+		return (
+			guild.members.resolve(group) ??
+			guild.roles.resolve(group) ??
+			this.#client.users.resolve(group)
+		);
+	}
+}

--- a/packages/perms/commands/perm.ts
+++ b/packages/perms/commands/perm.ts
@@ -1,6 +1,7 @@
 import { CompoundCommandBuilder } from 'core';
 import { feature as db } from 'db';
 import {
+	APIEmbed,
 	ApplicationCommandOptionChoiceData,
 	ChatInputCommandInteraction,
 	PermissionFlagsBits,
@@ -50,6 +51,23 @@ async function getPermissionOrInformNotFound(
 	return result;
 }
 
+function permissionToEmbed(permission: Permission): APIEmbed {
+	return {
+		color: 0x88ff44,
+		title: '権限情報',
+		fields: [
+			{
+				name: '権限名',
+				value: permission.name,
+			},
+			{
+				name: 'ロール/メンバー',
+				value: permission.group.join(', '),
+			},
+		],
+	};
+}
+
 builder
 	.subcommand('set', '値の更新')
 	.addStringOption({
@@ -75,10 +93,15 @@ builder
 			return;
 		}
 		const permissions = PermissionManager.forClient(interaction.client);
-		await permissions.set(interaction.guild, permissionName, group);
-		await interaction.reply(
-			`権限を追加しました!\n権限名: ${permissionName}\nロール/メンバー: ${group}`,
+		const permission = await permissions.set(
+			interaction.guild,
+			permissionName,
+			group,
 		);
+		await interaction.reply({
+			content: '権限を追加しました!',
+			embeds: [permissionToEmbed(permission)],
+		});
 	});
 
 builder
@@ -102,9 +125,9 @@ builder
 			permissionName,
 		);
 		if (permission != null) {
-			await interaction.reply(
-				`権限名: ${permissionName}\nロール/メンバー: ${permission}`,
-			);
+			await interaction.reply({
+				embeds: [permissionToEmbed(permission)],
+			});
 		}
 	});
 
@@ -129,9 +152,10 @@ builder
 		);
 		if (permission != null) {
 			await permission.remove();
-			await interaction.reply(
-				`権限を削除しました\n権限名: ${permissionName}\nロール/メンバー: ${permission}`,
-			);
+			await interaction.reply({
+				content: '権限を削除しました',
+				embeds: [permissionToEmbed(permission)],
+			});
 		}
 	});
 

--- a/packages/perms/commands/perm.ts
+++ b/packages/perms/commands/perm.ts
@@ -1,0 +1,78 @@
+import { CompoundCommandBuilder } from 'core';
+import { feature as db } from 'db';
+
+interface PermSchema {
+	guild: string;
+	name: string;
+	group: string;
+}
+
+const builder = new CompoundCommandBuilder('perm', '権限の設定');
+
+builder
+	.subcommand('set', '値の更新')
+	.addStringOption({
+		name: 'permission',
+		description: '権限名',
+		required: true,
+	})
+	.addMentionableOption({
+		name: 'group',
+		description: '対象のロールまたはユーザー',
+		required: true,
+	})
+	.build(async (interaction, permissionName, group) => {
+		const connection = db.connection;
+		const guild = interaction.guild;
+		if (guild == null) {
+			interaction.reply({
+				content: 'このコマンドはサーバー内で使用してください！',
+				ephemeral: true,
+			});
+			return;
+		}
+		const collection = connection.collection<PermSchema>('perms');
+		collection.insertOne({
+			guild: guild.id,
+			name: permissionName,
+			group: group.id,
+		});
+		await interaction.reply(
+			`権限を追加しました!\n権限名: ${permissionName}\nロール/メンバーID: ${group.id}`,
+		);
+	});
+
+builder
+	.subcommand('get', '値の取得')
+	.addStringOption({
+		name: 'permission',
+		description: '権限名',
+		required: true,
+	})
+	.build(async (interaction, permissionName) => {
+		const connection = db.connection;
+		const guild = interaction.guild;
+		if (guild == null) {
+			interaction.reply({
+				content: 'このコマンドはサーバー内で使用してください！',
+				ephemeral: true,
+			});
+			return;
+		}
+		const collection = connection.collection<PermSchema>('perms');
+		const result = await collection.findOne({
+			guild: guild.id,
+			name: permissionName,
+		});
+		if (result != null) {
+			await interaction.reply(
+				`権限名: ${permissionName}\nロール/メンバーID: ${result.group}`,
+			);
+		} else {
+			await interaction.reply(
+				`権限名: ${permissionName}\nその名前の権限はありません!`,
+			);
+		}
+	});
+
+export default builder.build();

--- a/packages/perms/commands/perm.ts
+++ b/packages/perms/commands/perm.ts
@@ -1,5 +1,6 @@
 import { CompoundCommandBuilder } from 'core';
 import { feature as db } from 'db';
+import { PermissionFlagsBits } from 'discord.js';
 
 interface PermSchema {
 	guild: string;
@@ -26,6 +27,15 @@ builder
 		if (!interaction.inCachedGuild()) {
 			interaction.reply({
 				content: 'このコマンドはサーバー内で使用してください！',
+				ephemeral: true,
+			});
+			return;
+		}
+		if (
+			!interaction.member.permissions.has(PermissionFlagsBits.Administrator)
+		) {
+			await interaction.reply({
+				content: '権限がありません！',
 				ephemeral: true,
 			});
 			return;

--- a/packages/perms/commands/perm.ts
+++ b/packages/perms/commands/perm.ts
@@ -1,9 +1,18 @@
 import { CompoundCommandBuilder } from 'core';
 import { feature as db } from 'db';
-import { PermissionFlagsBits } from 'discord.js';
+import {
+	ApplicationCommandOptionChoiceData,
+	PermissionFlagsBits,
+} from 'discord.js';
 import { PermissionManager } from '../PermissionManager';
 
 const builder = new CompoundCommandBuilder('perm', '権限の設定');
+
+const choices: ApplicationCommandOptionChoiceData<string>[] = [];
+
+export function addChoice(choice: ApplicationCommandOptionChoiceData<string>) {
+	choices.push(choice);
+}
 
 builder
 	.subcommand('set', '値の更新')
@@ -12,12 +21,7 @@ builder
 		description: '権限名',
 		required: true,
 		async autocomplete(interaction) {
-			await interaction.respond([
-				{
-					name: '自動応答の設定',
-					value: 'replyCustomize',
-				},
-			]);
+			await interaction.respond(choices);
 		},
 	})
 	.addMentionableOption({
@@ -57,12 +61,7 @@ builder
 		description: '権限名',
 		required: true,
 		async autocomplete(interaction) {
-			await interaction.respond([
-				{
-					name: '自動応答の設定',
-					value: 'replyCustomize',
-				},
-			]);
+			await interaction.respond(choices);
 		},
 	})
 	.build(async (interaction, permissionName) => {

--- a/packages/perms/commands/perm.ts
+++ b/packages/perms/commands/perm.ts
@@ -1,4 +1,4 @@
-import { CompoundCommandBuilder } from 'core';
+import { CompoundCommandBuilder, LANG, strFormat } from 'core';
 import { feature as db } from 'db';
 import {
 	APIEmbed,
@@ -8,7 +8,10 @@ import {
 } from 'discord.js';
 import { Permission, PermissionManager } from '../PermissionManager';
 
-const builder = new CompoundCommandBuilder('perm', '権限の設定');
+const builder = new CompoundCommandBuilder(
+	LANG.commands.perm.name,
+	LANG.commands.perm.description,
+);
 
 const choices: ApplicationCommandOptionChoiceData<string>[] = [];
 
@@ -18,7 +21,7 @@ export function addChoice(choice: ApplicationCommandOptionChoiceData<string>) {
 
 async function informNotInGuild(interaction: ChatInputCommandInteraction) {
 	await interaction.reply({
-		content: 'このコマンドはサーバー内で使用してください！',
+		content: LANG.common.message.useCommandInGuild,
 		ephemeral: true,
 	});
 	return;
@@ -29,7 +32,7 @@ async function checkMemberIsAdministrator(
 ): Promise<boolean> {
 	if (!interaction.member.permissions.has(PermissionFlagsBits.Administrator)) {
 		await interaction.reply({
-			content: '権限がありません！',
+			content: LANG.common.message.noPermission,
 			ephemeral: true,
 		});
 		return false;
@@ -45,7 +48,9 @@ async function getPermissionOrInformNotFound(
 	const result = await permissions.get(interaction.guild, permissionName);
 	if (result == null) {
 		await interaction.reply(
-			`権限名: ${permissionName}\nその名前の権限はありません!`,
+			LANG.commands.perm.noSuchPermission
+				.map((s) => strFormat(s, [permissionName]))
+				.join('\n'),
 		);
 	}
 	return result;
@@ -54,14 +59,14 @@ async function getPermissionOrInformNotFound(
 function permissionToEmbed(permission: Permission): APIEmbed {
 	return {
 		color: 0x88ff44,
-		title: '権限情報',
+		title: LANG.commands.perm.permissionInformation,
 		fields: [
 			{
-				name: '権限名',
+				name: LANG.commands.perm.permissionName,
 				value: permission.name,
 			},
 			{
-				name: 'ロール/メンバー',
+				name: LANG.commands.perm.permissionGroup,
 				value: permission.group.join(', '),
 			},
 		],
@@ -69,18 +74,21 @@ function permissionToEmbed(permission: Permission): APIEmbed {
 }
 
 builder
-	.subcommand('set', '値の更新')
+	.subcommand(
+		LANG.commands.perm.subcommands.set.name,
+		LANG.commands.perm.subcommands.set.description,
+	)
 	.addStringOption({
-		name: 'permission',
-		description: '権限名',
+		name: LANG.commands.perm.options.permission.name,
+		description: LANG.commands.perm.options.permission.description,
 		required: true,
 		async autocomplete(interaction) {
 			await interaction.respond(choices);
 		},
 	})
 	.addMentionableOption({
-		name: 'group',
-		description: '対象のロールまたはユーザー',
+		name: LANG.commands.perm.options.group.name,
+		description: LANG.commands.perm.options.group.description,
 		required: true,
 	})
 	.build(async (interaction, permissionName, group) => {
@@ -99,16 +107,19 @@ builder
 			group,
 		);
 		await interaction.reply({
-			content: '権限を追加しました!',
+			content: LANG.commands.perm.permissionSet,
 			embeds: [permissionToEmbed(permission)],
 		});
 	});
 
 builder
-	.subcommand('get', '値の取得')
+	.subcommand(
+		LANG.commands.perm.subcommands.get.name,
+		LANG.commands.perm.subcommands.get.description,
+	)
 	.addStringOption({
-		name: 'permission',
-		description: '権限名',
+		name: LANG.commands.perm.options.permission.name,
+		description: LANG.commands.perm.options.permission.description,
 		required: true,
 		async autocomplete(interaction) {
 			await interaction.respond(choices);
@@ -132,10 +143,13 @@ builder
 	});
 
 builder
-	.subcommand('remove', '値の削除')
+	.subcommand(
+		LANG.commands.perm.subcommands.remove.name,
+		LANG.commands.perm.subcommands.remove.description,
+	)
 	.addStringOption({
-		name: 'permission',
-		description: '権限名',
+		name: LANG.commands.perm.options.permission.name,
+		description: LANG.commands.perm.options.permission.description,
 		required: true,
 		async autocomplete(interaction) {
 			await interaction.respond(choices);
@@ -153,7 +167,7 @@ builder
 		if (permission != null) {
 			await permission.remove();
 			await interaction.reply({
-				content: '権限を削除しました',
+				content: LANG.commands.perm.permissionRemoved,
 				embeds: [permissionToEmbed(permission)],
 			});
 		}

--- a/packages/perms/commands/perm.ts
+++ b/packages/perms/commands/perm.ts
@@ -11,6 +11,14 @@ builder
 		name: 'permission',
 		description: '権限名',
 		required: true,
+		async autocomplete(interaction) {
+			await interaction.respond([
+				{
+					name: '自動応答の設定',
+					value: 'replyCustomize',
+				},
+			]);
+		},
 	})
 	.addMentionableOption({
 		name: 'group',
@@ -48,6 +56,14 @@ builder
 		name: 'permission',
 		description: '権限名',
 		required: true,
+		async autocomplete(interaction) {
+			await interaction.respond([
+				{
+					name: '自動応答の設定',
+					value: 'replyCustomize',
+				},
+			]);
+		},
 	})
 	.build(async (interaction, permissionName) => {
 		const connection = db.connection;

--- a/packages/perms/commands/perm.ts
+++ b/packages/perms/commands/perm.ts
@@ -23,8 +23,7 @@ builder
 	})
 	.build(async (interaction, permissionName, group) => {
 		const connection = db.connection;
-		const guild = interaction.guild;
-		if (guild == null) {
+		if (!interaction.inCachedGuild()) {
 			interaction.reply({
 				content: 'このコマンドはサーバー内で使用してください！',
 				ephemeral: true,
@@ -33,7 +32,7 @@ builder
 		}
 		const collection = connection.collection<PermSchema>('perms');
 		collection.insertOne({
-			guild: guild.id,
+			guild: interaction.guild.id,
 			name: permissionName,
 			group: group.id,
 		});
@@ -51,8 +50,7 @@ builder
 	})
 	.build(async (interaction, permissionName) => {
 		const connection = db.connection;
-		const guild = interaction.guild;
-		if (guild == null) {
+		if (!interaction.inCachedGuild()) {
 			interaction.reply({
 				content: 'このコマンドはサーバー内で使用してください！',
 				ephemeral: true,
@@ -61,7 +59,7 @@ builder
 		}
 		const collection = connection.collection<PermSchema>('perms');
 		const result = await collection.findOne({
-			guild: guild.id,
+			guild: interaction.guild.id,
 			name: permissionName,
 		});
 		if (result != null) {

--- a/packages/perms/commands/perm.ts
+++ b/packages/perms/commands/perm.ts
@@ -1,12 +1,7 @@
 import { CompoundCommandBuilder } from 'core';
 import { feature as db } from 'db';
 import { PermissionFlagsBits } from 'discord.js';
-
-interface PermSchema {
-	guild: string;
-	name: string;
-	group: string;
-}
+import { PermissionManager } from '../PermissionManager';
 
 const builder = new CompoundCommandBuilder('perm', '権限の設定');
 
@@ -40,14 +35,10 @@ builder
 			});
 			return;
 		}
-		const collection = connection.collection<PermSchema>('perms');
-		collection.insertOne({
-			guild: interaction.guild.id,
-			name: permissionName,
-			group: group.id,
-		});
+		const permissions = PermissionManager.forClient(interaction.client);
+		await permissions.set(interaction.guild, permissionName, group);
 		await interaction.reply(
-			`権限を追加しました!\n権限名: ${permissionName}\nロール/メンバーID: ${group.id}`,
+			`権限を追加しました!\n権限名: ${permissionName}\nロール/メンバー: ${group}`,
 		);
 	});
 
@@ -67,14 +58,11 @@ builder
 			});
 			return;
 		}
-		const collection = connection.collection<PermSchema>('perms');
-		const result = await collection.findOne({
-			guild: interaction.guild.id,
-			name: permissionName,
-		});
+		const permissions = PermissionManager.forClient(interaction.client);
+		const result = await permissions.get(interaction.guild, permissionName);
 		if (result != null) {
 			await interaction.reply(
-				`権限名: ${permissionName}\nロール/メンバーID: ${result.group}`,
+				`権限名: ${permissionName}\nロール/メンバー: ${result}`,
 			);
 		} else {
 			await interaction.reply(

--- a/packages/perms/commands/perm.ts
+++ b/packages/perms/commands/perm.ts
@@ -25,7 +25,7 @@ builder
 	.build(async (interaction, permissionName, group) => {
 		const connection = db.connection;
 		if (!interaction.inCachedGuild()) {
-			interaction.reply({
+			await interaction.reply({
 				content: 'このコマンドはサーバー内で使用してください！',
 				ephemeral: true,
 			});
@@ -61,7 +61,7 @@ builder
 	.build(async (interaction, permissionName) => {
 		const connection = db.connection;
 		if (!interaction.inCachedGuild()) {
-			interaction.reply({
+			await interaction.reply({
 				content: 'このコマンドはサーバー内で使用してください！',
 				ephemeral: true,
 			});

--- a/packages/perms/index.ts
+++ b/packages/perms/index.ts
@@ -1,6 +1,6 @@
 import { CommandManager, Feature } from 'core';
 import { Client } from 'discord.js';
-import perm from './commands/perm';
+import perm, { addChoice } from './commands/perm';
 import { feature as db } from 'db';
 import { PermissionManager } from './PermissionManager';
 
@@ -19,6 +19,13 @@ class PermsFeature extends Feature {
 
 	onClientReady(client: Client<true>): void | PromiseLike<void> {
 		this.permissions = PermissionManager.forClient(client);
+	}
+
+	registerPermission(name: string, description: string) {
+		addChoice({
+			name: description,
+			value: name,
+		});
 	}
 }
 

--- a/packages/perms/index.ts
+++ b/packages/perms/index.ts
@@ -1,9 +1,18 @@
-import { Feature } from 'core';
+import { CommandManager, Feature } from 'core';
+import { Client } from 'discord.js';
+import perm from './commands/perm';
+import { feature as db } from 'db';
 
 class PermsFeature extends Feature {
 	enabled: boolean = true;
 
 	name: string = 'perms';
+
+	dependencies: Feature[] = [db];
+
+	onLoad(client: Client<boolean>): void | PromiseLike<void> {
+		CommandManager.default.addCommands([perm]);
+	}
 }
 
 export const feature = new PermsFeature();

--- a/packages/perms/index.ts
+++ b/packages/perms/index.ts
@@ -23,7 +23,7 @@ class PermsFeature extends Feature {
 
 	registerPermission(name: string, description: string) {
 		addChoice({
-			name: description,
+			name: `${name} (${description})`,
 			value: name,
 		});
 	}

--- a/packages/perms/index.ts
+++ b/packages/perms/index.ts
@@ -1,0 +1,9 @@
+import { Feature } from 'core';
+
+class PermsFeature extends Feature {
+	enabled: boolean = true;
+
+	name: string = 'perms';
+}
+
+export const feature = new PermsFeature();

--- a/packages/perms/index.ts
+++ b/packages/perms/index.ts
@@ -2,6 +2,7 @@ import { CommandManager, Feature } from 'core';
 import { Client } from 'discord.js';
 import perm from './commands/perm';
 import { feature as db } from 'db';
+import { PermissionManager } from './PermissionManager';
 
 class PermsFeature extends Feature {
 	enabled: boolean = true;
@@ -10,8 +11,14 @@ class PermsFeature extends Feature {
 
 	dependencies: Feature[] = [db];
 
+	permissions?: PermissionManager;
+
 	onLoad(client: Client<boolean>): void | PromiseLike<void> {
 		CommandManager.default.addCommands([perm]);
+	}
+
+	onClientReady(client: Client<true>): void | PromiseLike<void> {
+		this.permissions = PermissionManager.forClient(client);
 	}
 }
 

--- a/packages/perms/index.ts
+++ b/packages/perms/index.ts
@@ -1,5 +1,5 @@
 import { CommandManager, Feature } from 'core';
-import { Client } from 'discord.js';
+import { Client, Guild, GuildMember } from 'discord.js';
 import perm, { addChoice } from './commands/perm';
 import { feature as db } from 'db';
 import { PermissionManager } from './PermissionManager';
@@ -26,6 +26,11 @@ class PermsFeature extends Feature {
 			name: `${name} (${description})`,
 			value: name,
 		});
+	}
+
+	async hasPermission(member: GuildMember, name: string): Promise<boolean> {
+		const permission = await this.permissions?.get(member.guild, name);
+		return permission != null && permission.hasMember(member);
 	}
 }
 

--- a/packages/perms/package.json
+++ b/packages/perms/package.json
@@ -1,0 +1,12 @@
+{
+	"name": "perms",
+	"version": "1.0.0",
+	"description": "",
+	"main": "index.ts",
+	"devDependencies": {},
+	"scripts": {
+		"test": "echo \"Error: no test specified\" && exit 1"
+	},
+	"author": "",
+	"license": "GPL-3.0-only"
+}


### PR DESCRIPTION
## 内容

<!--- PRの内容を記述 -->
/permコマンドにより、サーバー管理者が権限にロールやユーザーを割り当てることができるようになります。
今のところ、/reply コマンドによる自動応答の編集権限を設定できるようにしています。
- close #92

### 開発者向け使用例
```js
const { SlashCommandBuilder } = require('discord.js');
const { feature: perms } = require('perms');

perms.registerPermission('useHello', 'helloコマンドの使用');

module.exports = {
    data: new SlashCommandBuilder()
        .setName('hello')
        .setDescription('Hello, Sekai!'),
    async execute(/** @type {import('discord.js').ChatInputCommandInteraction} */ interaction) {
        if (interaction.inCachedGuild() && await perms.hasPermission(interaction.member, 'useHello')) {
            await interaction.reply('Hello, Sekai!');
        } else {
            await interaction.reply('このコマンドは使用できません!')
        }
    }
}

```

## 変更点

<!--- 変更点の記述 -->
- perms Feature、/perm コマンドの作成
- /perm コマンドによって設定された replyCustomize 権限を持っているメンバーは /replyコマンドによる自動応答の設定を行えるように
- Command インターフェイスに任意で `autocomplete` メソッドを持たせられるように
- `SimpleChoiceOptionData` の `autocomplete` フィールドをオプショナルな関数に変更
- `SimpleCommandBuilder` に `Mentionable` 型オプションを追加できるように

## チェックリスト:

<!--- チェックリストです。[x]のようにして印をつけられます。 -->

-   [x] このリポジトリのコードスタイルに沿っているか
-   [x] 自分自身で動作確認を行ったか、また、それは正常に動作したか
